### PR TITLE
Improve dev Docker reload, account token/session handling, and Vercel sync

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,19 @@ services:
     build: .
     image: ds2api:dev
     container_name: ds2api-dev
+    command: [
+      "uvicorn",
+      "app:app",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "5001",
+      "--reload",
+      "--reload-dir",
+      "/app",
+      "--log-level",
+      "debug"
+    ]
     ports:
       - "${PORT:-5001}:5001"
     env_file:
@@ -26,7 +39,7 @@ services:
       - ./routes:/app/routes:ro
       - ./static:/app/static:ro
       # 配置文件挂载（便于本地修改）
-      - ./config.json:/app/config.json:ro
+      - ./config.json:/app/config.json
     restart: "no"
     stdin_open: true
     tty: true

--- a/routes/admin/accounts.py
+++ b/routes/admin/accounts.py
@@ -36,23 +36,75 @@ async def validate_single_account(account: dict) -> dict:
         "has_token": bool(account.get("token", "").strip()),
         "message": "",
     }
-    
+
+    def _is_token_invalid(status_code: int, data: dict) -> bool:
+        msg = (data.get("msg") or data.get("message") or "").lower()
+        code = data.get("code")
+        return status_code in {401, 403} or code in {40001, 40002, 40003} or "token" in msg or "unauthorized" in msg
+
+    def _create_session(token: str) -> dict:
+        headers = {**BASE_HEADERS, "authorization": f"Bearer {token}"}
+        try:
+            session_resp = cffi_requests.post(
+                DEEPSEEK_CREATE_SESSION_URL,
+                headers=headers,
+                json={"agent": "chat"},
+                impersonate="safari15_3",
+                timeout=15,
+            )
+        except Exception as e:
+            return {"success": False, "message": f"请求异常: {e}", "status_code": 0, "data": {}}
+
+        try:
+            data = session_resp.json()
+        except Exception:
+            data = {}
+        finally:
+            session_resp.close()
+        if session_resp.status_code == 200 and data.get("code") == 0:
+            return {
+                "success": True,
+                "session_id": data.get("data", {}).get("biz_data", {}).get("id"),
+                "status_code": session_resp.status_code,
+                "data": data,
+            }
+        return {
+            "success": False,
+            "message": data.get("msg") or f"HTTP {session_resp.status_code}",
+            "status_code": session_resp.status_code,
+            "data": data,
+        }
+
     try:
-        if result["has_token"]:
-            result["valid"] = True
-            result["message"] = "已有有效 token"
-        else:
+        token = account.get("token", "").strip()
+        if token:
+            session_result = _create_session(token)
+            if session_result["success"]:
+                result["valid"] = True
+                result["message"] = "Token 有效"
+                return result
+
+            if _is_token_invalid(session_result["status_code"], session_result["data"]):
+                token = ""
+                account["token"] = ""
+
+        if not token:
             try:
                 login_deepseek_via_account(account)
-                result["valid"] = True
-                result["has_token"] = True
-                result["message"] = "登录成功"
+                token = account.get("token", "").strip()
+                session_result = _create_session(token)
+                if session_result["success"]:
+                    result["valid"] = True
+                    result["has_token"] = True
+                    result["message"] = "登录成功并验证通过"
+                else:
+                    result["message"] = f"登录成功但验证失败: {session_result['message']}"
             except Exception as e:
                 result["valid"] = False
                 result["message"] = f"登录失败: {str(e)}"
     except Exception as e:
         result["message"] = f"验证出错: {str(e)}"
-    
+
     return result
 
 
@@ -134,37 +186,67 @@ async def test_account_api(account: dict, model: str = "deepseek-chat", message:
     
     start_time = time.time()
     
+    def _is_token_invalid(status_code: int, data: dict) -> bool:
+        msg = (data.get("msg") or data.get("message") or "").lower()
+        code = data.get("code")
+        return status_code in {401, 403} or code in {40001, 40002, 40003} or "token" in msg or "unauthorized" in msg
+
+    def _create_session(token: str) -> dict:
+        headers = {**BASE_HEADERS, "authorization": f"Bearer {token}"}
+        try:
+            session_resp = cffi_requests.post(
+                DEEPSEEK_CREATE_SESSION_URL,
+                headers=headers,
+                json={"agent": "chat"},
+                impersonate="safari15_3",
+                timeout=15,
+            )
+        except Exception as e:
+            return {"success": False, "message": f"请求异常: {e}", "status_code": 0, "data": {}}
+
+        try:
+            session_data = session_resp.json()
+        except Exception:
+            session_data = {}
+        finally:
+            session_resp.close()
+
+        if session_resp.status_code == 200 and session_data.get("code") == 0:
+            return {
+                "success": True,
+                "session_id": session_data.get("data", {}).get("biz_data", {}).get("id"),
+                "status_code": session_resp.status_code,
+                "data": session_data,
+            }
+        return {
+            "success": False,
+            "message": session_data.get("msg") or f"HTTP {session_resp.status_code}",
+            "status_code": session_resp.status_code,
+            "data": session_data,
+        }
+
     try:
         token = account.get("token", "").strip()
-        if not token:
+        session_result = None
+        if token:
+            session_result = _create_session(token)
+
+        if not token or (session_result and not session_result["success"] and _is_token_invalid(session_result["status_code"], session_result["data"])):
             try:
+                account["token"] = ""
                 login_deepseek_via_account(account)
                 token = account.get("token", "")
+                session_result = _create_session(token)
             except Exception as e:
                 result["message"] = f"登录失败: {str(e)}"
                 return result
-        
+
+        if not session_result or not session_result["success"]:
+            result["message"] = f"创建会话失败: {session_result['message'] if session_result else 'Unknown error'}"
+            return result
+
+        session_id = session_result["session_id"]
         headers = {**BASE_HEADERS, "authorization": f"Bearer {token}"}
-        
-        session_resp = cffi_requests.post(
-            DEEPSEEK_CREATE_SESSION_URL,
-            headers=headers,
-            json={"agent": "chat"},
-            impersonate="safari15_3",
-            timeout=15,
-        )
-        
-        if session_resp.status_code != 200:
-            result["message"] = f"创建会话失败: HTTP {session_resp.status_code}"
-            return result
-        
-        session_data = session_resp.json()
-        if session_data.get("code") != 0:
-            result["message"] = f"创建会话失败: {session_data.get('msg', 'Unknown error')}"
-            account["token"] = ""
-            return result
-        
-        session_id = session_data.get("data", {}).get("biz_data", {}).get("id")
         
         if not message.strip():
             result["success"] = True

--- a/webui/src/components/VercelSync.jsx
+++ b/webui/src/components/VercelSync.jsx
@@ -47,7 +47,7 @@ export default function VercelSync({ onMessage, authFetch }) {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    vercel_token: vercelToken,
+                    vercel_token: tokenToUse,
                     project_id: projectId,
                     team_id: teamId || undefined,
                 }),


### PR DESCRIPTION
### Motivation
- 让本地开发容器支持 uvicorn 热重载并允许在容器中可修改配置文件以便调试与快速迭代。 
- 修复管理员侧账号验证/测试在遇到过期/无效 token 时未正确刷新或重试登录导致的误判与失败。 
- 在 Vercel 同步功能中支持使用预配置的 Vercel token（当页面未输入 token 时使用后端预配置）。

### Description
- Update `docker-compose.dev.yml` to run `uvicorn` explicitly with `--reload`/`--reload-dir` and change the config mount to writable so local edits to `config.json` persist in the container. 
- Rework account validation and testing in `routes/admin/accounts.py` to: use a shared `_create_session` helper that calls `DEEPSEEK_CREATE_SESSION_URL` and closes responses, detect token-invalid conditions (`401/403`, specific biz codes, or "token/unauthorized" messages), clear stale tokens, attempt `login_deepseek_via_account` and re-verify session, and return clearer failure messages; also ensure headers are available for subsequent PoW and completion requests. 
- Fix the web UI `VercelSync` component (`webui/src/components/VercelSync.jsx`) to send the computed `tokenToUse` (preconfigured token sentinel) to the backend instead of the raw `vercelToken` input. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823d0cb970832f84358a352dd70600)