### PR TITLE
Remove deprecated Vercel builds config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,5 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "app.py",
-      "use": "@vercel/python"
-    }
-  ],
   "buildCommand": "bash scripts/build-webui.sh",
   "rewrites": [
     {


### PR DESCRIPTION
### Motivation
- Remove deprecated `builds` from `vercel.json` so deployment uses the `buildCommand` (`bash scripts/build-webui.sh`) and avoids legacy builds config that can interfere with the WebUI build step.

### Description
- Deleted the `builds` array from `vercel.json` and preserved `buildCommand`, `rewrites`, and `headers` so the WebUI build is driven by the build command producing `static/admin/index.html`.

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698338999314832f97cdb244c642c934)