### PR TITLE
Fix indentation in non-streaming SSE parsing

### DIFF
--- a/routes/openai.py
+++ b/routes/openai.py
@@ -523,11 +523,11 @@ IMPORTANT: If calling tools, output ONLY the JSON. The response must start with 
                                     think_list.append(content_text)
                                 else:
                                     text_list.append(content_text)
-                            except Exception as e:
-                                logger.warning(f"[collect_data] 无法解析: {chunk}, 错误: {e}")
-                                text_list.append("解析失败，请稍候再试")
-                                data_queue.put(None)
-                                break
+                        except Exception as e:
+                            logger.warning(f"[collect_data] 无法解析: {chunk}, 错误: {e}")
+                            text_list.append("解析失败，请稍候再试")
+                            data_queue.put(None)
+                            break
                 except Exception as e:
                     logger.warning(f"[collect_data] 错误: {e}")
                     text_list.append("处理失败，请稍候再试")


### PR DESCRIPTION
### Motivation
- A mis-indented `except` in the non-streaming SSE parsing path of `routes/openai.py` caused a `SyntaxError` on import and crashed the serverless function, so the parser needed its try/except scope corrected.

### Description
- Corrected the indentation so the `except Exception as e:` pairs with the `try` that wraps the SSE chunk parsing loop in the non-streaming `collect_data` path of `routes/openai.py`, preventing the invalid syntax on import.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e87f1894832faab74beeadc00a3c)