### PR TITLE
Stream Go proxy responses to Vercel clients

### DIFF
--- a/internal/adapter/openai/vercel_stream.go
+++ b/internal/adapter/openai/vercel_stream.go
@@ -56,11 +56,6 @@ func (h *Handler) handleVercelStreamPrepare(w http.ResponseWriter, r *http.Reque
 		writeOpenAIError(w, http.StatusBadRequest, "stream must be true")
 		return
 	}
-	if tools, ok := req["tools"].([]any); ok && len(tools) > 0 {
-		writeOpenAIError(w, http.StatusBadRequest, "tools are not supported by vercel stream prepare")
-		return
-	}
-
 	model, _ := req["model"].(string)
 	messagesRaw, _ := req["messages"].([]any)
 	if model == "" || len(messagesRaw) == 0 {
@@ -74,6 +69,9 @@ func (h *Handler) handleVercelStreamPrepare(w http.ResponseWriter, r *http.Reque
 	}
 
 	messages := normalizeMessages(messagesRaw)
+	if tools, ok := req["tools"].([]any); ok && len(tools) > 0 {
+		messages, _ = injectToolPrompt(messages, tools)
+	}
 	finalPrompt := util.MessagesPrepare(messages)
 
 	sessionID, err := h.DS.CreateSession(r.Context(), a, 3)


### PR DESCRIPTION
### Motivation
- Node-side proxy previously buffered the full Go upstream response with `arrayBuffer()` which prevented Vercel clients from receiving incremental streamed chunks.
- Vercel streaming flow must deliver chunks to the client in real time even when the request is proxied to the Go backend.
- The Vercel prepare handler should accept `tools` and inject tool prompts instead of rejecting requests so JS streaming remains usable for tool-using requests.

### Description
- Update `proxyToGo` in `api/chat-stream.js` to read `upstream.body.getReader()` and `res.write()` chunks as they arrive, with `res.flush()` when available, and fall back to buffered `arrayBuffer()` when a reader is not present.
- Add guarded error handling to ensure responses are `end()`ed on exceptions and avoid leaving writable streams open.
- Allow tool-related instructions to be injected into the Vercel stream prepare flow by calling `injectToolPrompt` when `tools` are present in `internal/adapter/openai/vercel_stream.go` instead of returning an error.

### Testing
- Ran `node --check api/chat-stream.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699385c66ab4832fb873318c950bb508)