### PR TITLE
feat: Standardize tool name fallback to 'unknown' for parity with Go and ensure `parseTool` consistently returns raw input on parsing failures.

### DIFF
--- a/api/helpers/stream-tool-sieve.js
+++ b/api/helpers/stream-tool-sieve.js
@@ -14,9 +14,9 @@ function extractToolNames(tools) {
     }
     const fn = t.function && typeof t.function === 'object' ? t.function : t;
     const name = toStringSafe(fn.name);
-    if (name) {
-      out.push(name);
-    }
+    // Keep parity with Go injectToolPrompt: object tools without name still
+    // enter tool mode via fallback name "unknown".
+    out.push(name || 'unknown');
   }
   return out;
 }
@@ -413,10 +413,10 @@ function parseToolCallInput(v) {
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         return parsed;
       }
+      return { _raw: raw };
     } catch (_err) {
       return { _raw: raw };
     }
-    return {};
   }
   if (typeof v === 'object' && !Array.isArray(v)) {
     return v;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

---

> 💡 **提示**：如果修改了 `webui/` 目录下的文件，PR 合并后 CI 会自动构建并提交产物，无需手动构建。