### PR TITLE
ci: build and publish Docker images in release workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-and-upload:
@@ -81,3 +82,35 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/sha256sums.txt
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }}
+            type=raw,value=latest
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ RUN npm run build
 
 FROM golang:1.24 AS go-builder
 WORKDIR /app
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/ds2api ./cmd/ds2api
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ds2api ./cmd/ds2api
 
 FROM debian:bookworm-slim
 WORKDIR /app


### PR DESCRIPTION
### Motivation

- The release workflow did not publish a Docker image to a container registry, so add image build and push during release events. 
- Ensure multi-architecture images produce correct binaries by making the Go build step in the `Dockerfile` parameterizable for target OS/arch.

### Description

- Updated `.github/workflows/release-artifacts.yml` to grant `packages: write` and add steps to set up QEMU, Buildx, log in to GHCR, extract Docker metadata, and run `docker/build-push-action@v6` to build and push multi-arch images for `linux/amd64,linux/arm64` with the release tag and `latest`.
- Added `ARG TARGETOS=linux` and `ARG TARGETARCH=amd64` to the `Dockerfile` and changed the Go build to use `GOOS=${TARGETOS} GOARCH=${TARGETARCH}` so multi-arch buildx builds produce correct binaries.
- The workflow tags images under `ghcr.io/${{ github.repository }}` and uses `GITHUB_TOKEN` for authentication.

### Testing

- Ran `go test ./...` in the repository and all package tests that exist completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699452bfecc0832fb79a1dc3ce726a8c)