### PR TITLE
ci: include docker image artifacts in release assets

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-and-upload:
@@ -72,6 +73,59 @@ jobs:
             rm -rf "${STAGE}"
           done
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }}
+            type=raw,value=latest
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Export Docker image archives for release assets
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+
+          docker buildx build \
+            --platform linux/amd64 \
+            --output type=docker,dest="dist/ds2api_${TAG}_docker_linux_amd64.tar" \
+            .
+
+          docker buildx build \
+            --platform linux/arm64 \
+            --output type=docker,dest="dist/ds2api_${TAG}_docker_linux_arm64.tar" \
+            .
+
+          gzip -f "dist/ds2api_${TAG}_docker_linux_amd64.tar"
+          gzip -f "dist/ds2api_${TAG}_docker_linux_arm64.tar"
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
           (cd dist && sha256sum *.tar.gz *.zip > sha256sums.txt)
 
       - name: Upload Release Assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ RUN npm run build
 
 FROM golang:1.24 AS go-builder
 WORKDIR /app
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/ds2api ./cmd/ds2api
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ds2api ./cmd/ds2api
 
 FROM debian:bookworm-slim
 WORKDIR /app


### PR DESCRIPTION
### Motivation
- GitHub Release pages only list uploaded release assets, while images pushed to GHCR via `docker/build-push-action` do not appear in the Release Assets list. 
- Provide downloadable Docker image archives alongside the built binaries so releases contain both registry images and downloadable image files. 

### Description
- Updated `.github/workflows/release-artifacts.yml` to export single-platform Docker image archives by running `docker buildx build --output type=docker,dest=...` for `linux/amd64` and `linux/arm64` and gzip the resulting `.tar` files. 
- Moved checksum generation to the end and ensured `Upload Release Assets` runs after all archives are produced so `sha256sums.txt` includes the new Docker archives. 
- Kept multi-arch GHCR push steps (QEMU, buildx, `docker/build-push-action`) so images are still published to the package registry and also added the exported tar.gz files to `dist/` for release assets. 
- Updated `Dockerfile` to add `ARG TARGETOS=linux` and `ARG TARGETARCH=amd64` and build with `GOOS=${TARGETOS} GOARCH=${TARGETARCH}` so `buildx` multi-arch builds produce correct binaries. 

### Testing
- Validated YAML syntax of `.github/workflows/release-artifacts.yml` with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-artifacts.yml'); puts 'ok'"`, which succeeded. 
- Ran `go test ./...` and all package tests that exist completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699452bfecc0832fb79a1dc3ce726a8c)