### PR TITLE
fix(node): 移除被过滤工具调用的回退重发并对齐 Go 行为

### DIFF
--- a/internal/js/helpers/stream-tool-sieve/parse.js
+++ b/internal/js/helpers/stream-tool-sieve/parse.js
@@ -263,14 +263,6 @@ function filterToolCalls(parsed, toolNames) {
     }
     out.push({ name: tc.name, input: tc.input || {} });
   }
-  if (out.length === 0 && parsed.length > 0) {
-    for (const tc of parsed) {
-      if (!tc || !tc.name) {
-        continue;
-      }
-      out.push({ name: tc.name, input: tc.input || {} });
-    }
-  }
   return out;
 }
 

--- a/tests/node/stream-tool-sieve.test.js
+++ b/tests/node/stream-tool-sieve.test.js
@@ -52,11 +52,19 @@ test('parseToolCalls keeps non-object argument strings as _raw (Go parity)', () 
   ]);
 });
 
-test('parseToolCalls still intercepts unknown schema names to avoid leaks', () => {
+test('parseToolCalls drops unknown schema names when toolNames is provided', () => {
   const payload = JSON.stringify({
     tool_calls: [{ name: 'not_in_schema', input: { q: 'go' } }],
   });
   const calls = parseToolCalls(payload, ['search']);
+  assert.equal(calls.length, 0);
+});
+
+test('parseToolCalls keeps unknown names when toolNames is empty', () => {
+  const payload = JSON.stringify({
+    tool_calls: [{ name: 'not_in_schema', input: { q: 'go' } }],
+  });
+  const calls = parseToolCalls(payload, []);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].name, 'not_in_schema');
 });


### PR DESCRIPTION
### Motivation
- 修复在 `toolNames` 非空时，JS 端会在过滤掉未知工具名后将已解析的工具调用回填并重新发出，导致 Vercel 流式下未知工具（例如 `unknown_tool`）仍以 `tool_calls` 形式发出而不是保持为普通文本，从而与 Go 端行为不一致并破坏兼容性约定。

### Description
- 删除 `internal/js/helpers/stream-tool-sieve/parse.js` 中 `filterToolCalls` 在过滤结果为空时回填原始解析结果的“兜底回发”逻辑，使其在 `toolNames` 提供时严格丢弃不在允许集合内的工具调用。 
- 更新并补充 `tests/node/stream-tool-sieve.test.js`，新增断言以验证当 `toolNames` 提供且不匹配时未知工具会被丢弃，并保留 `toolNames` 为空时的原有行为。
- 该改动使 Node/Vercel 的流式工具调用拦截与 Go 端行为对齐，避免在受限工具名列表下错误地转发未知工具调用为 `tool_calls` 事件。
- 修改范围限于 JS 解析/筛选逻辑和相应单元测试，无其他运行时或接口变更。

### Testing
- 运行节点语法检查脚本 `./tests/scripts/check-node-split-syntax.sh`，结果为 `checked=18 missing=0 invalid=0`，通过。 
- 运行单元测试 `node --test tests/node/stream-tool-sieve.test.js tests/node/chat-stream.test.js tests/node/js_compat_test.js`，共 `29` 个子测试全部通过（pass 29 / fail 0）。
- 修改后的测试均通过，表明行为已按预期修正并与 Go 端对齐。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699b1a3c2d34832fbe55e1d0359eeae1)