### PR TITLE
ci: 增强 release-artifacts 工作流对 GHCR 超时与上传失败的容错

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -85,12 +85,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for GHCR endpoint
+        run: |
+          set -euo pipefail
+          for i in {1..6}; do
+            if curl -fsSIL --max-time 15 https://ghcr.io/v2/ >/dev/null; then
+              exit 0
+            fi
+            sleep "$((i * 10))"
+          done
+          echo "GHCR endpoint is unreachable after multiple retries." >&2
+          exit 1
+
+      - name: Log in to GHCR (with retry)
+        run: |
+          set -euo pipefail
+          for i in {1..6}; do
+            if echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin; then
+              exit 0
+            fi
+            sleep "$((i * 10))"
+          done
+          echo "Failed to login to GHCR after multiple retries." >&2
+          exit 1
 
       - name: Extract Docker metadata
         id: meta_release
@@ -104,6 +121,9 @@ jobs:
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+          DOCKER_BUILD_SUMMARY: "false"
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
### Motivation
- 近期在发布流程中出现 `Get "https://ghcr.io/v2/": context deadline exceeded` 和 `Failed to FinalizeCacheEntryUpload: ... ETIMEDOUT` 等偶发网络/上传超时错误，需提升对 GHCR 网络波动与构建记录上传环节的鲁棒性。

### Description
- 在 `.github/workflows/release-artifacts.yml` 中新增 `Wait for GHCR endpoint` 步骤，使用 `curl` 对 `https://ghcr.io/v2/` 进行多次重试与退避等待以提前检测可达性。 
- 将 GHCR 登录由 `docker/login-action` 替换为带重试的 shell 登录脚本（通过 `docker login --password-stdin`），以降低临时网络抖动导致的登录失败概率。 
- 为 `docker/build-push-action@v6` 设置环境变量 `DOCKER_BUILD_RECORD_UPLOAD=false` 与 `DOCKER_BUILD_SUMMARY=false`，以规避构建记录/缓存上传阶段触发的超时失败。 
- 仅修改文件为 ` .github/workflows/release-artifacts.yml`，不影响业务代码或产物格式。 

### Testing
- 已通过 `nl -ba .github/workflows/release-artifacts.yml` 检查并确认工作流文件内容已按预期更新，检查成功。 
- 尝试通过 `go install github.com/rhysd/actionlint/cmd/actionlint@latest` 安装并运行 `actionlint` 校验，但因访问 Go Proxy 被拒绝（403），安装失败，无法完成该项 lint 校验。 
- 尝试用 Python `yaml.safe_load` 解析工作流以校验 YAML 语法，但运行环境缺少 `PyYAML` 导致解析步骤未能执行。 
- 工作流更改已写入工作区并准备纳入后续 CI 运行以做真实发布验证，后续运行是否稳定将以 GitHub Actions 实际执行结果为准。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699b317ffef8832f8c3dafb94d3a829f)