### PR TITLE
ci: 修复 release-artifacts 中 GHCR 探测 405 并调整登录顺序

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -85,12 +85,37 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR (with retry)
+        run: |
+          set -euo pipefail
+          for i in {1..6}; do
+            if echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin; then
+              exit 0
+            fi
+            echo "Login failed, retrying in $((i * 10))s..."
+            sleep "$((i * 10))"
+          done
+          echo "Failed to login to GHCR after multiple retries." >&2
+          exit 1
+
+      - name: Wait for GHCR endpoint
+        run: |
+          set -euo pipefail
+          for i in {1..6}; do
+            status_code="$(curl -sS -o /dev/null -w "%{http_code}" --max-time 15 \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://ghcr.io/v2/ || true)"
+
+            if [ "${status_code}" = "200" ] || [ "${status_code}" = "401" ]; then
+              echo "GHCR is reachable (HTTP ${status_code})."
+              exit 0
+            fi
+
+            echo "Waiting for GHCR endpoint, retrying in $((i * 10))s... (HTTP ${status_code})"
+            sleep "$((i * 10))"
+          done
+          echo "GHCR endpoint is unreachable after multiple retries." >&2
+          exit 1
 
       - name: Extract Docker metadata
         id: meta_release
@@ -104,6 +129,9 @@ jobs:
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+          DOCKER_BUILD_SUMMARY: "false"
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
### Motivation
- 修复在 `Wait for GHCR endpoint` 步骤中使用 HEAD 请求导致对 GHCR 返回 `405` 并被误判为不可达的问题。 
- 提升在 GHCR 网络抖动或鉴权挑战场景下发布流程的稳定性与可观测性。 
- 降低临时网络/鉴权抖动对后续镜像登录、推送与资产导出的影响。 

### Description
- 将 GHCR 登录由 `docker/login-action` 替换为带重试的 shell 登录脚本，并把登录步骤移动到探测步骤之前以确保凭证可用。 
- 修复探测逻辑：使用带 `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}` 的普通请求读取 HTTP 状态码（不再用 HEAD），并将 `200` 与 `401` 视为可达。 
- 在登录与探测的重试循环中增加日志输出以便定位（包含重试等待时长与 HTTP 状态码）。 
- 为 `docker/build-push-action@v6` 增加环境变量 `DOCKER_BUILD_RECORD_UPLOAD=false` 与 `DOCKER_BUILD_SUMMARY=false` 以降低构建记录/摘要上传引发的超时失败。 

### Testing
- 使用 Ruby `YAML.load_file` 成功解析 `.github/workflows/release-artifacts.yml`，校验通过。 
- 对 workflow 中每个 `run` 脚本块逐一执行 `bash -n` 进行 shell 语法校验，所有脚本块语法检查通过。 
- 已在工作区应用并验证变更文件内容与 shell 语法无误，准备纳入 CI 实际运行进一步验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699b317ffef8832f8c3dafb94d3a829f)