### PR TITLE
feat: 账号测试状态持久化、分页选择器、点击账号名复制

### DIFF
--- a/internal/admin/deps.go
+++ b/internal/admin/deps.go
@@ -16,6 +16,7 @@ type ConfigStore interface {
 	Accounts() []config.Account
 	FindAccount(identifier string) (config.Account, bool)
 	UpdateAccountToken(identifier, token string) error
+	UpdateAccountTestStatus(identifier, status string) error
 	Update(mutator func(*config.Config) error) error
 	ExportJSONAndBase64() (string, string, error)
 	IsEnvBacked() bool

--- a/internal/admin/handler_accounts_crud.go
+++ b/internal/admin/handler_accounts_crud.go
@@ -56,6 +56,7 @@ func (h *Handler) listAccounts(w http.ResponseWriter, r *http.Request) {
 			"has_password":  acc.Password != "",
 			"has_token":     token != "",
 			"token_preview": preview,
+			"test_status":   acc.TestStatus,
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"items": items, "total": total, "page": page, "page_size": pageSize, "total_pages": totalPages})

--- a/internal/admin/handler_accounts_testing.go
+++ b/internal/admin/handler_accounts_testing.go
@@ -88,7 +88,15 @@ func runAccountTestsConcurrently(accounts []config.Account, maxConcurrency int, 
 
 func (h *Handler) testAccount(ctx context.Context, acc config.Account, model, message string) map[string]any {
 	start := time.Now()
-	result := map[string]any{"account": acc.Identifier(), "success": false, "response_time": 0, "message": "", "model": model}
+	identifier := acc.Identifier()
+	result := map[string]any{"account": identifier, "success": false, "response_time": 0, "message": "", "model": model}
+	defer func() {
+		status := "failed"
+		if ok, _ := result["success"].(bool); ok {
+			status = "ok"
+		}
+		_ = h.Store.UpdateAccountTestStatus(identifier, status)
+	}()
 	token := strings.TrimSpace(acc.Token)
 	if token == "" {
 		newToken, err := h.DS.Login(ctx, acc)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,10 +18,11 @@ type Config struct {
 }
 
 type Account struct {
-	Email    string `json:"email,omitempty"`
-	Mobile   string `json:"mobile,omitempty"`
-	Password string `json:"password,omitempty"`
-	Token    string `json:"token,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Mobile     string `json:"mobile,omitempty"`
+	Password   string `json:"password,omitempty"`
+	Token      string `json:"token,omitempty"`
+	TestStatus string `json:"test_status,omitempty"`
 }
 
 type CompatConfig struct {

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -97,6 +97,18 @@ func (s *Store) FindAccount(identifier string) (Account, bool) {
 	return Account{}, false
 }
 
+func (s *Store) UpdateAccountTestStatus(identifier, status string) error {
+	identifier = strings.TrimSpace(identifier)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx, ok := s.findAccountIndexLocked(identifier)
+	if !ok {
+		return errors.New("account not found")
+	}
+	s.cfg.Accounts[idx].TestStatus = status
+	return s.saveLocked()
+}
+
 func (s *Store) UpdateAccountToken(identifier, token string) error {
 	identifier = strings.TrimSpace(identifier)
 	s.mu.Lock()

--- a/webui/src/features/account/AccountManagerContainer.jsx
+++ b/webui/src/features/account/AccountManagerContainer.jsx
@@ -17,10 +17,12 @@ export default function AccountManagerContainer({ config, onRefresh, onMessage, 
         setKeysExpanded,
         accounts,
         page,
+        pageSize,
         totalPages,
         totalAccounts,
         loadingAccounts,
         fetchAccounts,
+        changePageSize,
         resolveAccountIdentifier,
     } = useAccountsData({ apiFetch })
 
@@ -79,6 +81,7 @@ export default function AccountManagerContainer({ config, onRefresh, onMessage, 
                 batchProgress={batchProgress}
                 totalAccounts={totalAccounts}
                 page={page}
+                pageSize={pageSize}
                 totalPages={totalPages}
                 resolveAccountIdentifier={resolveAccountIdentifier}
                 onTestAll={testAllAccounts}
@@ -87,6 +90,7 @@ export default function AccountManagerContainer({ config, onRefresh, onMessage, 
                 onDeleteAccount={deleteAccount}
                 onPrevPage={() => fetchAccounts(page - 1)}
                 onNextPage={() => fetchAccounts(page + 1)}
+                onPageSizeChange={changePageSize}
             />
 
             <AddKeyModal

--- a/webui/src/features/account/useAccountsData.js
+++ b/webui/src/features/account/useAccountsData.js
@@ -6,7 +6,7 @@ export function useAccountsData({ apiFetch }) {
 
     const [accounts, setAccounts] = useState([])
     const [page, setPage] = useState(1)
-    const [pageSize] = useState(10)
+    const [pageSize, setPageSize] = useState(10)
     const [totalPages, setTotalPages] = useState(1)
     const [totalAccounts, setTotalAccounts] = useState(0)
     const [loadingAccounts, setLoadingAccounts] = useState(false)
@@ -16,10 +16,10 @@ export function useAccountsData({ apiFetch }) {
         return String(acc.identifier || acc.email || acc.mobile || '').trim()
     }
 
-    const fetchAccounts = async (targetPage = page) => {
+    const fetchAccounts = async (targetPage = page, targetPageSize = pageSize) => {
         setLoadingAccounts(true)
         try {
-            const res = await apiFetch(`/admin/accounts?page=${targetPage}&page_size=${pageSize}`)
+            const res = await apiFetch(`/admin/accounts?page=${targetPage}&page_size=${targetPageSize}`)
             if (res.ok) {
                 const data = await res.json()
                 setAccounts(data.items || [])
@@ -32,6 +32,11 @@ export function useAccountsData({ apiFetch }) {
         } finally {
             setLoadingAccounts(false)
         }
+    }
+
+    const changePageSize = (newSize) => {
+        setPageSize(newSize)
+        fetchAccounts(1, newSize)
     }
 
     const fetchQueueStatus = async () => {
@@ -59,10 +64,12 @@ export function useAccountsData({ apiFetch }) {
         setKeysExpanded,
         accounts,
         page,
+        pageSize,
         totalPages,
         totalAccounts,
         loadingAccounts,
         fetchAccounts,
+        changePageSize,
         resolveAccountIdentifier,
     }
 }

--- a/webui/src/locales/en.json
+++ b/webui/src/locales/en.json
@@ -113,6 +113,7 @@
         "testingAllAccounts": "Testing all accounts...",
         "sessionActive": "Session active",
         "reauthRequired": "Re-auth required",
+        "testStatusFailed": "Last test failed",
         "noAccounts": "No accounts found.",
         "modalAddKeyTitle": "Add API key",
         "newKeyLabel": "New key value",

--- a/webui/src/locales/zh.json
+++ b/webui/src/locales/zh.json
@@ -113,6 +113,7 @@
         "testingAllAccounts": "正在测试所有账号...",
         "sessionActive": "已建立会话",
         "reauthRequired": "需重新登录",
+        "testStatusFailed": "上次测试失败",
         "noAccounts": "未找到任何账号",
         "modalAddKeyTitle": "添加 API 密钥",
         "newKeyLabel": "新密钥值",


### PR DESCRIPTION
## Summary

- **账号测试状态持久化**：Account 结构新增 `test_status` 字段，测试后将结果（`ok`/`failed`）写入 `config.json`；账号列表接口返回 `test_status`，前端根据结果显示红/绿/黄状态点及对应文字
- **分页选择器**：账号列表分页栏新增每页条数选择器，支持 10/20/50/100/500/1000/2000/5000
- **点击账号名复制**：点击账号名自动复制到剪贴板，hover 显示复制图标，复制成功后显示绿色对勾 1.5 秒

## Test plan

- [ ] 测试账号后刷新页面，确认状态点颜色正确保留（红/绿）
- [ ] 切换每页条数，确认列表正确刷新并重置到第 1 页
- [ ] 点击账号名，确认剪贴板内容正确，图标正常切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)