### PR TITLE
Use repository root Dockerfile, make Go cross-build robust, and fix process wait logic

### DIFF
--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -113,7 +113,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./docker/Dockerfile
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./docker/Dockerfile
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ RUN npm run build
 
 FROM golang:1.24 AS go-builder
 WORKDIR /app
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ds2api ./cmd/ds2api
+RUN set -eux; \
+    GOOS="${TARGETOS:-$(go env GOOS)}"; \
+    GOARCH="${TARGETARCH:-$(go env GOARCH)}"; \
+    CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" go build -o /out/ds2api ./cmd/ds2api
 
 FROM busybox:1.36.1-musl AS busybox-tools
 

--- a/start.mjs
+++ b/start.mjs
@@ -338,7 +338,8 @@ function showStatus() {
 function waitForProcesses() {
   return new Promise(resolve => {
     const check = setInterval(() => {
-      if (processes.filter(p => !p.killed).length === 0) {
+      const activeCount = processes.filter(proc => proc.exitCode === null && proc.signalCode === null).length;
+      if (activeCount === 0) {
         clearInterval(check);
         resolve();
       }


### PR DESCRIPTION
### Motivation

- Align CI release workflows to the repository root `Dockerfile` path so Buildx can find the Dockerfile used for multi-arch images. 
- Make the Go build in the Dockerfile robust when `TARGETOS`/`TARGETARCH` are not provided by falling back to `go env` values. 
- Improve build reliability by failing fast and making the build step verbose. 
- Fix incorrect child-process liveness detection in `start.mjs` so the script can wait for spawned processes reliably.

### Description

- Updated `.github/workflows/release.yml` and `.github/workflows/release-dockerhub.yml` to use `file: ./Dockerfile` instead of `./docker/Dockerfile` for the `docker/build-push-action`. 
- Modified `Dockerfile` to remove hard-coded default `ARG` values and to compute `GOOS`/`GOARCH` with `GOOS="${TARGETOS:-$(go env GOOS)}"` and `GOARCH="${TARGETARCH:-$(go env GOARCH)}"`, and replaced the `go build` line with a `set -eux` wrapper to improve error visibility. 
- Kept the multi-stage layout and artifacts but made the Go build step deterministic for both provided and absent `TARGET*` args. 
- Fixed `waitForProcesses` in `start.mjs` to count active processes using `proc.exitCode === null && proc.signalCode === null` instead of relying on `p.killed`.

### Testing

- Ran local multi-arch builds using `docker buildx build` with `--platform linux/amd64,linux/arm64` against the updated `Dockerfile`, and image builds completed successfully. 
- Executed a local smoke test of the start script and confirmed the updated `waitForProcesses` correctly detects running children and resolves when they exit. 
- CI release workflows were updated to the new `Dockerfile` path so subsequent GitHub Actions runs will exercise the updated build steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a2c38ed330832496f66df8f4acb870)