### PR TITLE
Normalize mobile login numbers, skip completion flow for session-only account tests, and add tests

### DIFF
--- a/internal/admin/handler_accounts_testing.go
+++ b/internal/admin/handler_accounts_testing.go
@@ -125,7 +125,10 @@ func (h *Handler) testAccount(ctx context.Context, acc config.Account, model, me
 		}
 	}
 	if strings.TrimSpace(message) == "" {
-		message = "你是谁？"
+		result["success"] = true
+		result["message"] = "API 测试成功（仅会话创建）"
+		result["response_time"] = int(time.Since(start).Milliseconds())
+		return result
 	}
 	thinking, search, ok := config.GetModelConfig(model)
 	if !ok {

--- a/internal/admin/handler_accounts_testing_test.go
+++ b/internal/admin/handler_accounts_testing_test.go
@@ -1,0 +1,76 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"ds2api/internal/auth"
+	"ds2api/internal/config"
+)
+
+type testingDSMock struct {
+	loginCalls          int
+	createSessionCalls  int
+	getPowCalls         int
+	callCompletionCalls int
+}
+
+func (m *testingDSMock) Login(_ context.Context, _ config.Account) (string, error) {
+	m.loginCalls++
+	return "new-token", nil
+}
+
+func (m *testingDSMock) CreateSession(_ context.Context, _ *auth.RequestAuth, _ int) (string, error) {
+	m.createSessionCalls++
+	return "session-id", nil
+}
+
+func (m *testingDSMock) GetPow(_ context.Context, _ *auth.RequestAuth, _ int) (string, error) {
+	m.getPowCalls++
+	return "", errors.New("should not call GetPow in this test")
+}
+
+func (m *testingDSMock) CallCompletion(_ context.Context, _ *auth.RequestAuth, _ map[string]any, _ string, _ int) (*http.Response, error) {
+	m.callCompletionCalls++
+	return nil, errors.New("should not call CallCompletion in this test")
+}
+
+func TestTestAccount_BatchModeOnlyCreatesSession(t *testing.T) {
+	t.Setenv("DS2API_CONFIG_JSON", `{"accounts":[{"email":"batch@example.com","password":"pwd","token":""}]}`)
+	store := config.LoadStore()
+	ds := &testingDSMock{}
+	h := &Handler{Store: store, DS: ds}
+	acc, ok := store.FindAccount("batch@example.com")
+	if !ok {
+		t.Fatal("expected test account")
+	}
+
+	result := h.testAccount(context.Background(), acc, "deepseek-chat", "")
+
+	if ok, _ := result["success"].(bool); !ok {
+		t.Fatalf("expected success=true, got %#v", result)
+	}
+	msg, _ := result["message"].(string)
+	if !strings.Contains(msg, "仅会话创建") {
+		t.Fatalf("expected session-only success message, got %q", msg)
+	}
+	if ds.loginCalls != 1 || ds.createSessionCalls != 1 {
+		t.Fatalf("unexpected Login/CreateSession calls: login=%d createSession=%d", ds.loginCalls, ds.createSessionCalls)
+	}
+	if ds.getPowCalls != 0 || ds.callCompletionCalls != 0 {
+		t.Fatalf("expected no completion flow calls, got getPow=%d callCompletion=%d", ds.getPowCalls, ds.callCompletionCalls)
+	}
+	updated, ok := store.FindAccount("batch@example.com")
+	if !ok {
+		t.Fatal("expected updated account")
+	}
+	if updated.Token != "new-token" {
+		t.Fatalf("expected refreshed token to be persisted, got %q", updated.Token)
+	}
+	if updated.TestStatus != "ok" {
+		t.Fatalf("expected test status ok, got %q", updated.TestStatus)
+	}
+}

--- a/internal/deepseek/client_auth.go
+++ b/internal/deepseek/client_auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"unicode"
 
 	"ds2api/internal/auth"
 	"ds2api/internal/config"
@@ -20,8 +21,9 @@ func (c *Client) Login(ctx context.Context, acc config.Account) (string, error) 
 	if email := strings.TrimSpace(acc.Email); email != "" {
 		payload["email"] = email
 	} else if mobile := strings.TrimSpace(acc.Mobile); mobile != "" {
-		payload["mobile"] = mobile
-		payload["area_code"] = nil
+		loginMobile, areaCode := normalizeMobileForLogin(mobile)
+		payload["mobile"] = loginMobile
+		payload["area_code"] = areaCode
 	} else {
 		return "", errors.New("missing email/mobile")
 	}
@@ -150,4 +152,27 @@ func isTokenInvalid(status int, code int, msg string) bool {
 		return true
 	}
 	return strings.Contains(msg, "token") || strings.Contains(msg, "unauthorized")
+}
+
+func normalizeMobileForLogin(raw string) (mobile string, areaCode any) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", nil
+	}
+	hasPlus := strings.HasPrefix(s, "+")
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	digits := b.String()
+	if digits == "" {
+		return "", nil
+	}
+	if (hasPlus || strings.HasPrefix(digits, "86")) && strings.HasPrefix(digits, "86") && len(digits) == 13 {
+		return digits[2:], nil
+	}
+	return digits, nil
 }

--- a/internal/deepseek/client_auth_mobile_test.go
+++ b/internal/deepseek/client_auth_mobile_test.go
@@ -1,0 +1,33 @@
+package deepseek
+
+import "testing"
+
+func TestNormalizeMobileForLogin_ChinaWithPlus86(t *testing.T) {
+	mobile, areaCode := normalizeMobileForLogin("+8613800138000")
+	if mobile != "13800138000" {
+		t.Fatalf("unexpected mobile: %q", mobile)
+	}
+	if areaCode != nil {
+		t.Fatalf("expected nil areaCode, got %#v", areaCode)
+	}
+}
+
+func TestNormalizeMobileForLogin_ChinaWith86Prefix(t *testing.T) {
+	mobile, areaCode := normalizeMobileForLogin("8613800138000")
+	if mobile != "13800138000" {
+		t.Fatalf("unexpected mobile: %q", mobile)
+	}
+	if areaCode != nil {
+		t.Fatalf("expected nil areaCode, got %#v", areaCode)
+	}
+}
+
+func TestNormalizeMobileForLogin_KeepPlainDigits(t *testing.T) {
+	mobile, areaCode := normalizeMobileForLogin("13800138000")
+	if mobile != "13800138000" {
+		t.Fatalf("unexpected mobile: %q", mobile)
+	}
+	if areaCode != nil {
+		t.Fatalf("expected nil areaCode, got %#v", areaCode)
+	}
+}


### PR DESCRIPTION
### Motivation

- Ensure mobile numbers are normalized for login requests and area code handling is correct.
- Avoid performing full completion calls when the admin account test is invoked in session-only mode (empty message), to reduce unnecessary network calls.

### Description

- Added `normalizeMobileForLogin` in `internal/deepseek/client_auth.go` to strip non-digit characters and normalize `+86`/`86` Chinese mobile prefixes before sending login payloads and wire the returned `area_code` into the login payload.
- Changed `Login` payload construction to use `normalizeMobileForLogin` and include `area_code` appropriately.
- Updated `testAccount` in `internal/admin/handler_accounts_testing.go` to short-circuit and mark the test as successful when `message` is empty (session-only test), avoiding `GetPow`/`CallCompletion` calls and returning a clear message `API 测试成功（仅会话创建）`.
- Added unit tests: `internal/deepseek/client_auth_mobile_test.go` to verify mobile normalization behavior and `internal/admin/handler_accounts_testing_test.go` to verify session-only account testing only creates a session, refreshes token, persists status, and does not call completion-related flows.

### Testing

- Ran the new admin test with `go test ./internal/admin -run TestTestAccount_BatchModeOnlyCreatesSession`, which passed.
- Ran the deepseek tests with `go test ./internal/deepseek -run TestNormalizeMobileForLogin_*`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5ade1d1d08324b11ef4ee7ff0d91b)