### PR TITLE
Resolve PR #82 merge conflicts and restore tool-call parsing (invoke/argument and XML arguments)

### DIFF
--- a/internal/util/toolcalls_parse_markup.go
+++ b/internal/util/toolcalls_parse_markup.go
@@ -15,6 +15,7 @@ var antmlArgumentPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_]+:)?argument\s+
 var antmlParametersPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_]+:)?parameters\s*>\s*(\{.*?\})\s*</(?:[a-z0-9_]+:)?parameters>`)
 var invokeCallPattern = regexp.MustCompile(`(?is)<invoke\s+name="([^"]+)"\s*>(.*?)</invoke>`)
 var invokeParamPattern = regexp.MustCompile(`(?is)<parameter\s+name="([^"]+)"\s*>\s*(.*?)\s*</parameter>`)
+var invokeArgumentPattern = regexp.MustCompile(`(?is)<argument(?:\s+name="([^"]+)")?\s*>\s*(.*?)\s*</argument>`)
 
 func parseXMLToolCalls(text string) []ParsedToolCall {
 	matches := xmlToolCallPattern.FindAllString(text, -1)
@@ -109,6 +110,14 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 			if tag == "tool" {
 				inTool = false
 			}
+		}
+	}
+	if fallback := parseMarkupSingleToolCall("", inner); fallback.Name != "" {
+		if strings.TrimSpace(name) == "" {
+			name = fallback.Name
+		}
+		if len(params) == 0 && strings.EqualFold(strings.TrimSpace(fallback.Name), strings.TrimSpace(name)) {
+			params = fallback.Input
 		}
 	}
 	if strings.TrimSpace(name) == "" {
@@ -207,6 +216,23 @@ func parseInvokeFunctionCallStyle(text string) (ParsedToolCall, bool) {
 		k := strings.TrimSpace(pm[1])
 		v := strings.TrimSpace(pm[2])
 		if k != "" {
+			input[k] = v
+		}
+	}
+	for _, am := range invokeArgumentPattern.FindAllStringSubmatch(m[2], -1) {
+		if len(am) < 3 {
+			continue
+		}
+		key := strings.TrimSpace(am[1])
+		raw := strings.TrimSpace(am[2])
+		if raw == "" {
+			continue
+		}
+		if key != "" {
+			input[key] = raw
+			continue
+		}
+		for k, v := range parseToolCallInput(raw) {
 			input[k] = v
 		}
 	}

--- a/internal/util/toolcalls_test.go
+++ b/internal/util/toolcalls_test.go
@@ -271,7 +271,6 @@ func TestParseToolCallsSupportsMultipleAntmlFunctionCalls(t *testing.T) {
 		t.Fatalf("expected canonical names [bash read], got %#v", calls)
 	}
 }
-
 func TestParseToolCallsDoesNotAcceptMismatchedMarkupTags(t *testing.T) {
 	text := `<tool_call><name>read_file</function><arguments>{"path":"README.md"}</arguments></tool_call>`
 	calls := ParseToolCalls(text, []string{"read_file"})


### PR DESCRIPTION
### Motivation
- Merge `origin/dev` into the PR branch produced conflicts in the tool-call parsing tests and introduced regressions that caused compat fixtures to fail.
- Ensure Go-side parsing behavior matches expected compat fixtures (XML `<arguments>`, `<invoke>` with `<argument>` payloads) and keep the mismatched-markup regression test.

### Description
- Resolved merge conflict in `internal/util/toolcalls_test.go` and retained the mismatched-markup rejection test (`TestParseToolCallsDoesNotAcceptMismatchedMarkupTags`).
- Added `invokeArgumentPattern` and extended `parseInvokeFunctionCallStyle` in `internal/util/toolcalls_parse_markup.go` to handle `<argument>` elements both with and without `name` attributes, including JSON unwrapping for unnamed `<argument>` bodies.
- Added a fallback merge in `parseSingleXMLToolCall` that uses `parseMarkupSingleToolCall` to preserve payloads inside `<arguments>{...}</arguments>` when the XML path yields empty params, restoring expected fixture behavior.

### Testing
- Ran `go test ./internal/util ./internal/compat`, which initially exposed the regression and then passed after the fixes (final result: passed).
- Ran `go test ./...` after fixes, and the full test suite passed (all packages reported `ok` or `[no test files]`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac62aaba8483249185243e485cd31b)