### PR TITLE
fix: parse invoke/tool_call arguments in xml compatibility paths

### DIFF
--- a/internal/util/toolcalls_parse_markup.go
+++ b/internal/util/toolcalls_parse_markup.go
@@ -93,6 +93,15 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 				if err := dec.DecodeElement(&v, &t); err == nil && strings.TrimSpace(v) != "" {
 					name = strings.TrimSpace(v)
 				}
+			case "input", "arguments", "argument", "args", "params":
+				var v string
+				if err := dec.DecodeElement(&v, &t); err == nil && strings.TrimSpace(v) != "" {
+					if parsed := parseToolCallInput(strings.TrimSpace(v)); len(parsed) > 0 {
+						for k, vv := range parsed {
+							params[k] = vv
+						}
+					}
+				}
 			default:
 				if inParams || inTool {
 					var v string
@@ -208,6 +217,13 @@ func parseInvokeFunctionCallStyle(text string) (ParsedToolCall, bool) {
 		v := strings.TrimSpace(pm[2])
 		if k != "" {
 			input[k] = v
+		}
+	}
+	if len(input) == 0 {
+		if argsRaw := findMarkupTagValue(m[2], toolCallMarkupArgsTagNames, toolCallMarkupArgsPatternByTag); argsRaw != "" {
+			input = parseMarkupInput(argsRaw)
+		} else if kv := parseMarkupKVObject(m[2]); len(kv) > 0 {
+			input = kv
 		}
 	}
 	return ParsedToolCall{Name: name, Input: input}, true


### PR DESCRIPTION
### Motivation
- XML/markup toolcall fixtures were losing argument payloads for `<tool_call>` and `<invoke>` styles because `<arguments>`/`<input>`/`<argument>` blocks were not being parsed into the tool `input` map.
- This caused compatibility test fixtures (Go vs JS) to report empty `input` for cases that contained JSON or KV-style child tags.

### Description
- Update `internal/util/toolcalls_parse_markup.go` to collect argument payloads from XML child tags by decoding `<input>`, `<arguments>`, `<argument>`, `<args>`, and `<params>` and merging parsed JSON into the `params` map in `parseSingleXMLToolCall`.
- Enhance `parseInvokeFunctionCallStyle` to fall back to extracting arguments via `findMarkupTagValue` + `parseMarkupInput` or `parseMarkupKVObject` when `<parameter>` entries are absent, so `<invoke name="...">...</invoke>` cases correctly populate `input`.
- These changes restore parity with existing fixtures that embed JSON in argument/arguments tags and handle generic key-value child tags.

### Testing
- Ran `./tests/scripts/check-refactor-line-gate.sh` which passed (no missing/over-limit files).
- Ran `./tests/scripts/run-unit-all.sh` which executed unit tests and the JS compat suite; all tests passed.
- Ran `go test ./internal/util ./internal/compat` which passed and confirmed the toolcall fixtures are now correct.
- Built the WebUI with `npm ci --prefix webui` and `npm run build --prefix webui`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acfafb6c788324809a9a090ae4bb83)