### PR TITLE
ci: ignore test files in line gate and raise frontend limit to 500

### DIFF
--- a/plans/refactor-line-gate-targets.txt
+++ b/plans/refactor-line-gate-targets.txt
@@ -1,6 +1,8 @@
 # Line gate targets for large-file decoupling refactor.
-# Default limit: 300 lines
+# Backend default limit: 300 lines
+# Frontend (webui/) default limit: 500 lines
 # Entry/facade limit: 120 lines (enforced in script)
+# Test files are ignored by the gate script.
 
 internal/config/config.go
 internal/config/logger.go

--- a/plans/refactor-line-gate.md
+++ b/plans/refactor-line-gate.md
@@ -2,10 +2,11 @@
 
 ## Rules
 
-1. Production file default upper bound: `<= 300` lines.
-2. Entry/facade files upper bound: `<= 120` lines.
-3. Scope is limited to target files in `plans/refactor-line-gate-targets.txt`.
-4. Test files are out of scope for this gate.
+1. Backend production files upper bound: `<= 300` lines.
+2. Frontend (`webui/`) production files upper bound: `<= 500` lines.
+3. Entry/facade files upper bound: `<= 120` lines.
+4. Scope is limited to target files in `plans/refactor-line-gate-targets.txt`.
+5. Test files are out of scope for this gate.
 
 ## Command
 

--- a/tests/scripts/check-refactor-line-gate.sh
+++ b/tests/scripts/check-refactor-line-gate.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 TARGETS_FILE="$ROOT_DIR/plans/refactor-line-gate-targets.txt"
 
 DEFAULT_MAX=300
+FRONTEND_MAX=500
 ENTRY_MAX=120
 
 is_entry_file() {
@@ -22,6 +23,27 @@ is_entry_file() {
   return 1
 }
 
+is_frontend_file() {
+  [[ "$1" == webui/* ]]
+}
+
+is_test_file() {
+  local file="$1"
+  local base
+  base="$(basename "$file")"
+
+  [[ "$file" == tests/* ]] && return 0
+  [[ "$file" == */tests/* ]] && return 0
+  [[ "$file" == */__tests__/* ]] && return 0
+  [[ "$base" == *_test.go ]] && return 0
+  [[ "$base" == *.test.js ]] && return 0
+  [[ "$base" == *.test.jsx ]] && return 0
+  [[ "$base" == *.test.ts ]] && return 0
+  [[ "$base" == *.test.tsx ]] && return 0
+
+  return 1
+}
+
 if [[ ! -f "$TARGETS_FILE" ]]; then
   echo "missing targets file: $TARGETS_FILE" >&2
   exit 1
@@ -35,6 +57,10 @@ while IFS= read -r file; do
   [[ -z "$file" ]] && continue
   [[ "${file:0:1}" == "#" ]] && continue
 
+  if is_test_file "$file"; then
+    continue
+  fi
+
   checked=$((checked + 1))
   abs="$ROOT_DIR/$file"
   if [[ ! -f "$abs" ]]; then
@@ -45,7 +71,9 @@ while IFS= read -r file; do
 
   lines="$(wc -l < "$abs" | tr -d ' ')"
   limit="$DEFAULT_MAX"
-  if is_entry_file "$file"; then
+  if is_frontend_file "$file"; then
+    limit="$FRONTEND_MAX"
+  elif is_entry_file "$file"; then
     limit="$ENTRY_MAX"
   fi
 


### PR DESCRIPTION
### Motivation

- The refactor line-count gate should not block changes to test files, so test files must be excluded from the check.
- Frontend source (`webui/`) requires a more permissive line limit than backend production files.
- Keep entry/facade files with a stricter upper bound to encourage small surface files.

### Description

- Added `FRONTEND_MAX=500` and `is_frontend_file` to `tests/scripts/check-refactor-line-gate.sh` so `webui/*` files use a 500-line threshold.
- Added `is_test_file` to detect and skip test files (matches `tests/`, `*/tests/*`, `*/__tests__/*`, `*_test.go`, and common `*.test.*` patterns) in the gate script.
- Updated script logic to skip test files during scanning and to apply frontend/entry limits in the correct order (`webui/` -> frontend limit, entry files -> 120 limit, otherwise backend default 300).
- Synchronized documentation and targets header comments in `plans/refactor-line-gate.md` and `plans/refactor-line-gate-targets.txt` to state backend 300, frontend 500, and that tests are ignored.

### Testing

- Ran the gate script `./tests/scripts/check-refactor-line-gate.sh` and it completed successfully with `checked=130 missing=0 over_limit=0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b815907a38832989a62d5b3348ffd8)