### PR TITLE
Align Vercel JS stream tool-call delta handling with Go runtime

### DIFF
--- a/internal/js/chat-stream/vercel_stream.js
+++ b/internal/js/chat-stream/vercel_stream.js
@@ -1,35 +1,22 @@
 'use strict';
 
 const {
-  extractToolNames,
   createToolSieveState,
   processToolSieveChunk,
   flushToolSieve,
   parseStandaloneToolCalls,
   formatOpenAIStreamToolCalls,
 } = require('../helpers/stream-tool-sieve');
-const {
-  BASE_HEADERS,
-} = require('../shared/deepseek-constants');
-
-const {
-  writeOpenAIError,
-} = require('./error_shape');
-const {
-  parseChunkForContent,
-  isCitation,
-} = require('./sse_parse');
-const {
-  buildUsage,
-} = require('./token_usage');
+const { BASE_HEADERS } = require('../shared/deepseek-constants');
+const { writeOpenAIError } = require('./error_shape');
+const { parseChunkForContent, isCitation } = require('./sse_parse');
+const { buildUsage } = require('./token_usage');
 const {
   resolveToolcallPolicy,
   formatIncrementalToolCallDeltas,
   filterIncrementalToolCallDeltasByAllowed,
 } = require('./toolcall_policy');
-const {
-  createChatCompletionEmitter,
-} = require('./stream_emitter');
+const { createChatCompletionEmitter } = require('./stream_emitter');
 const {
   asString,
   isAbortError,


### PR DESCRIPTION
### Motivation
- Make the Vercel JS streaming path strictly match the Go runtime for incremental tool-call deltas so streaming behavior and tool-call filtering/ID stability are identical across runtimes and avoid leaking or mis-emitting incremental arguments.

### Description
- Import `formatIncrementalToolCallDeltas` and `filterIncrementalToolCallDeltasByAllowed` into `internal/js/chat-stream/vercel_stream.js` and wire them into the streaming path.
- Respect the prepared `emitEarlyToolDeltas` flag and handle `tool_call_deltas` events by filtering allowed names, formatting incremental deltas, and emitting them as early tool-call deltas when enabled.
- Track per-index seen tool names via `streamToolNames` and maintain stable streaming IDs via `streamToolCallIDs` so incremental deltas and final calls align with Go-side semantics.

### Testing
- Ran `node --test tests/node/chat-stream.test.js tests/node/js_compat_test.js` and the Node test suite passed with no failures.
- The modified `internal/js/chat-stream/vercel_stream.js` file was validated by the existing JS compatibility and chat-stream tests which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc80bebd0083299c9ed13f8106830b)