### PR TITLE
Align Vercel JS toolcall detection/format behavior with Go semantics

### DIFF
--- a/internal/js/chat-stream/toolcall_policy.js
+++ b/internal/js/chat-stream/toolcall_policy.js
@@ -60,6 +60,9 @@ function formatIncrementalToolCallDeltas(deltas, idStore) {
     if (typeof d.arguments === 'string' && d.arguments !== '') {
       fn.arguments = d.arguments;
     }
+    if (Object.keys(fn).length === 0) {
+      continue;
+    }
     if (Object.keys(fn).length > 0) {
       item.function = fn;
     }

--- a/internal/js/helpers/stream-tool-sieve/parse.js
+++ b/internal/js/helpers/stream-tool-sieve/parse.js
@@ -17,15 +17,18 @@ function extractToolNames(tools) {
     return [];
   }
   const out = [];
+  const seen = new Set();
   for (const t of tools) {
     if (!t || typeof t !== 'object') {
       continue;
     }
     const fn = t.function && typeof t.function === 'object' ? t.function : t;
     const name = toStringSafe(fn.name);
-    // Keep parity with Go injectToolPrompt: object tools without name still
-    // enter tool mode via fallback name "unknown".
-    out.push(name || 'unknown');
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    out.push(name);
   }
   return out;
 }

--- a/tests/node/chat-stream.test.js
+++ b/tests/node/chat-stream.test.js
@@ -98,6 +98,12 @@ test('incremental and final tool formatting share stable id via idStore', () => 
   assert.equal(incremental[0].id, finalCalls[0].id);
 });
 
+test('formatIncrementalToolCallDeltas drops empty deltas (Go parity)', () => {
+  const idStore = new Map();
+  const formatted = formatIncrementalToolCallDeltas([{ index: 0 }], idStore);
+  assert.deepEqual(formatted, []);
+});
+
 test('parseChunkForContent keeps split response/content fragments inside response array', () => {
   const chunk = {
     p: 'response',

--- a/tests/node/stream-tool-sieve.test.js
+++ b/tests/node/stream-tool-sieve.test.js
@@ -31,13 +31,14 @@ function collectText(events) {
     .join('');
 }
 
-test('extractToolNames keeps tool mode enabled with unknown fallback', () => {
+test('extractToolNames keeps only declared tool names (Go parity)', () => {
   const names = extractToolNames([
     { function: { description: 'no name tool' } },
     { function: { name: ' read_file ' } },
+    { function: { name: 'read_file' } },
     {},
   ]);
-  assert.deepEqual(names, ['unknown', 'read_file', 'unknown']);
+  assert.deepEqual(names, ['read_file']);
 });
 
 test('parseToolCalls keeps non-object argument strings as _raw (Go parity)', () => {


### PR DESCRIPTION
### Motivation
- Ensure Vercel/Node tool-call handling matches the Go runtime semantics so Vercel deployments behave identically for tool detection and incremental formatting.
- Two behavioral divergences were observed: empty incremental deltas being emitted and tool-name extraction producing `unknown` fallbacks and duplicates.

### Description
- Stop emitting empty incremental tool deltas by updating `formatIncrementalToolCallDeltas` in `internal/js/chat-stream/toolcall_policy.js` to drop deltas that contain neither `name` nor `arguments`.
- Align tool-name extraction with Go by changing `extractToolNames` in `internal/js/helpers/stream-tool-sieve/parse.js` to only include declared, non-empty tool names and to deduplicate names (remove the `unknown` fallback behavior).
- Add/update Node tests to lock in parity: `tests/node/chat-stream.test.js` gets a case verifying empty deltas are dropped and `tests/node/stream-tool-sieve.test.js` is updated to expect only declared tool names.

### Testing
- Ran `node --test tests/node/chat-stream.test.js tests/node/stream-tool-sieve.test.js tests/node/js_compat_test.js` and all test cases passed (node test runner output shows all suites OK).
- Attempted `npm test -- ...` but it failed due to a missing `package.json` at the repository root (this is an environment issue, not related to the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd6f1db8cc8329a8863d762d4036f4)