### PR TITLE
fix: decouple runtime-from-dist image from go-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ FROM busybox:1.36.1-musl AS busybox-tools
 
 FROM debian:bookworm-slim AS runtime-base
 WORKDIR /app
-COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=busybox-tools /bin/busybox /usr/local/bin/busybox
 EXPOSE 5001
 CMD ["/usr/local/bin/ds2api"]


### PR DESCRIPTION
### Motivation
- The release `buildx` failed because `runtime-from-dist` indirectly depended on the `go-builder` stage via `COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt`, which forced an unnecessary `go build` (with `-X ds2api/internal/version.BuildVersion=...`) to run and fail during the Docker multi-stage build.

### Description
- Update `Dockerfile` `runtime-base` stage to install `ca-certificates` via `apt-get` instead of copying them from the `go-builder` stage, removing the unintended dependency on `go-builder` and ensuring `docker buildx --target runtime-from-dist` does not execute the source compile.
- No other source files were modified; the change is limited to replacing the `COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt ...` with an `apt-get install ca-certificates` sequence in `Dockerfile`.

### Testing
- Ran release gating scripts `./tests/scripts/check-stage6-manual-smoke.sh` which passed (output: `stage6_manual_smoke=PASS`).
- Ran line-gate check `./tests/scripts/check-refactor-line-gate.sh` which passed (output: `checked=130 missing=0 over_limit=0`).
- Ran unit suite `./tests/scripts/run-unit-all.sh` which completed successfully with all tests passing (summary: `# pass 41 # fail 0`).
- Built Web UI with `npm ci --prefix webui` and `npm run build --prefix webui` which succeeded, and replayed the multi-platform Go build loop locally using `go build -ldflags='-X ds2api/internal/version.BuildVersion=...'` for the target set, which completed successfully; full `docker buildx` runs could not be executed here because Docker is unavailable, but the stage-coupling root cause has been removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bd7f1c4a4c832998467675b82e1e61)