### PR TITLE
Merge pull request #118 from CJackHwang/codex/analyze-and-fix-build-failure-for-pr-117

fix: decouple runtime-from-dist image from go-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ FROM busybox:1.36.1-musl AS busybox-tools
 
 FROM debian:bookworm-slim AS runtime-base
 WORKDIR /app
-COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=busybox-tools /bin/busybox /usr/local/bin/busybox
 EXPOSE 5001
 CMD ["/usr/local/bin/ds2api"]


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->