### PR TITLE
fix: allow Docker builds without BUILD_VERSION

### DIFF
--- a/DEPLOY.en.md
+++ b/DEPLOY.en.md
@@ -181,6 +181,7 @@ Notes:
 
 - **Port**: DS2API listens on `5001` by default; the template sets `PORT=5001`.
 - **Persistent config**: the template mounts `/data` and sets `DS2API_CONFIG_PATH=/data/config.json`. After importing config in Admin UI, it will be written and persisted to this path.
+- **Build version**: Zeabur / regular `docker build` does not require `BUILD_VERSION` by default. The image prefers that build arg when provided, and automatically falls back to the repo-root `VERSION` file when it is absent.
 - **First login**: after deployment, open `/admin` and login with `DS2API_ADMIN_KEY` shown in Zeabur env/template instructions (recommended: rotate to a strong secret after first login).
 
 ---

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -181,6 +181,7 @@ healthcheck:
 
 - **端口**：服务默认监听 `5001`，模板会固定设置 `PORT=5001`。
 - **配置持久化**：模板挂载卷 `/data`，并设置 `DS2API_CONFIG_PATH=/data/config.json`；在管理台导入配置后，会写入并持久化到该路径。
+- **构建版本号**：Zeabur / 普通 `docker build` 默认不需要传 `BUILD_VERSION`；镜像会优先使用该构建参数，未提供时自动回退到仓库根目录的 `VERSION` 文件。
 - **首次登录**：部署完成后访问 `/admin`，使用 Zeabur 环境变量/模板指引中的 `DS2API_ADMIN_KEY` 登录（建议首次登录后自行更换为强密码）。
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN set -eux; \
     GOOS="${TARGETOS:-$(go env GOOS)}"; \
     GOARCH="${TARGETARCH:-$(go env GOARCH)}"; \
-    BUILD_VERSION_RESOLVED="${BUILD_VERSION}"; \
+    BUILD_VERSION_RESOLVED="${BUILD_VERSION:-}"; \
     if [ -z "${BUILD_VERSION_RESOLVED}" ] && [ -f VERSION ]; then BUILD_VERSION_RESOLVED="$(cat VERSION | tr -d "[:space:]")"; fi; \
     CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X ds2api/internal/version.BuildVersion=${BUILD_VERSION_RESOLVED}" -o /out/ds2api ./cmd/ds2api
 

--- a/README.MD
+++ b/README.MD
@@ -178,6 +178,8 @@ docker-compose logs -f
 2. 部署完成后访问 `/admin`，使用 Zeabur 环境变量/模板指引中的 `DS2API_ADMIN_KEY` 登录。
 3. 在管理台导入/编辑配置（会写入并持久化到 `/data/config.json`）。
 
+说明：Zeabur 使用仓库内 `Dockerfile` 直接构建时，不需要额外传入 `BUILD_VERSION`；镜像会优先读取该构建参数，未提供时自动回退到仓库根目录的 `VERSION` 文件。
+
 ### 方式三：Vercel 部署
 
 1. Fork 仓库到自己的 GitHub

--- a/README.en.md
+++ b/README.en.md
@@ -178,6 +178,8 @@ Rebuild after updates: `docker-compose up -d --build`
 2. After deployment, open `/admin` and login with `DS2API_ADMIN_KEY` shown in Zeabur env/template instructions.
 3. Import / edit config in Admin UI (it will be written and persisted to `/data/config.json`).
 
+Note: when Zeabur builds directly from the repo `Dockerfile`, you do not need to pass `BUILD_VERSION`. The image prefers that build arg when provided, and automatically falls back to the repo-root `VERSION` file when it is absent.
+
 ### Option 3: Vercel
 
 1. Fork this repo to your GitHub account

--- a/zeabur.yaml
+++ b/zeabur.yaml
@@ -16,6 +16,7 @@ spec:
     - Admin panel: `/admin`
     - Health check: `/healthz`
     - Config is persisted at `/data/config.json` (mounted volume)
+    - `BUILD_VERSION` is optional; when omitted, Docker build falls back to the repo `VERSION` file automatically
 
     ## First-time setup
     1. Open your service URL, then visit `/admin`


### PR DESCRIPTION
## Summary
- fix the Docker `go-builder` stage so `BUILD_VERSION` is optional under `set -u`
- keep the existing version resolution order: explicit build arg, then repo `VERSION`, then empty value
- document the fallback behavior for Zeabur and regular Docker builds in both docs and the Zeabur template

## Root cause
Zeabur builds the repo `Dockerfile` without passing `BUILD_VERSION`. The current shell step expands `${BUILD_VERSION}` before fallback logic runs, so `/bin/sh` exits with `parameter not set`.

## Testing
- verified shell fallback behavior with `set -u` when `BUILD_VERSION` is unset
- verified explicit `BUILD_VERSION` still wins when provided
- ran `git diff --check`
- could not run full `docker build` or Go tests in this environment because `docker` and `go` are unavailable
