### PR TITLE
fix: 修复 Docker 在缺少 BUILD_VERSION 时构建失败

### DIFF
--- a/DEPLOY.en.md
+++ b/DEPLOY.en.md
@@ -181,6 +181,7 @@ Notes:
 
 - **Port**: DS2API listens on `5001` by default; the template sets `PORT=5001`.
 - **Persistent config**: the template mounts `/data` and sets `DS2API_CONFIG_PATH=/data/config.json`. After importing config in Admin UI, it will be written and persisted to this path.
+- **Build version**: Zeabur / regular `docker build` does not require `BUILD_VERSION` by default. The image prefers that build arg when provided, and automatically falls back to the repo-root `VERSION` file when it is absent.
 - **First login**: after deployment, open `/admin` and login with `DS2API_ADMIN_KEY` shown in Zeabur env/template instructions (recommended: rotate to a strong secret after first login).
 
 ---

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -181,6 +181,7 @@ healthcheck:
 
 - **端口**：服务默认监听 `5001`，模板会固定设置 `PORT=5001`。
 - **配置持久化**：模板挂载卷 `/data`，并设置 `DS2API_CONFIG_PATH=/data/config.json`；在管理台导入配置后，会写入并持久化到该路径。
+- **构建版本号**：Zeabur / 普通 `docker build` 默认不需要传 `BUILD_VERSION`；镜像会优先使用该构建参数，未提供时自动回退到仓库根目录的 `VERSION` 文件。
 - **首次登录**：部署完成后访问 `/admin`，使用 Zeabur 环境变量/模板指引中的 `DS2API_ADMIN_KEY` 登录（建议首次登录后自行更换为强密码）。
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN set -eux; \
     GOOS="${TARGETOS:-$(go env GOOS)}"; \
     GOARCH="${TARGETARCH:-$(go env GOARCH)}"; \
-    BUILD_VERSION_RESOLVED="${BUILD_VERSION}"; \
+    BUILD_VERSION_RESOLVED="${BUILD_VERSION:-}"; \
     if [ -z "${BUILD_VERSION_RESOLVED}" ] && [ -f VERSION ]; then BUILD_VERSION_RESOLVED="$(cat VERSION | tr -d "[:space:]")"; fi; \
     CGO_ENABLED=0 GOOS="${GOOS}" GOARCH="${GOARCH}" go build -ldflags="-s -w -X ds2api/internal/version.BuildVersion=${BUILD_VERSION_RESOLVED}" -o /out/ds2api ./cmd/ds2api
 

--- a/README.MD
+++ b/README.MD
@@ -178,6 +178,8 @@ docker-compose logs -f
 2. 部署完成后访问 `/admin`，使用 Zeabur 环境变量/模板指引中的 `DS2API_ADMIN_KEY` 登录。
 3. 在管理台导入/编辑配置（会写入并持久化到 `/data/config.json`）。
 
+说明：Zeabur 使用仓库内 `Dockerfile` 直接构建时，不需要额外传入 `BUILD_VERSION`；镜像会优先读取该构建参数，未提供时自动回退到仓库根目录的 `VERSION` 文件。
+
 ### 方式三：Vercel 部署
 
 1. Fork 仓库到自己的 GitHub

--- a/README.en.md
+++ b/README.en.md
@@ -178,6 +178,8 @@ Rebuild after updates: `docker-compose up -d --build`
 2. After deployment, open `/admin` and login with `DS2API_ADMIN_KEY` shown in Zeabur env/template instructions.
 3. Import / edit config in Admin UI (it will be written and persisted to `/data/config.json`).
 
+Note: when Zeabur builds directly from the repo `Dockerfile`, you do not need to pass `BUILD_VERSION`. The image prefers that build arg when provided, and automatically falls back to the repo-root `VERSION` file when it is absent.
+
 ### Option 3: Vercel
 
 1. Fork this repo to your GitHub account

--- a/zeabur.yaml
+++ b/zeabur.yaml
@@ -16,6 +16,7 @@ spec:
     - Admin panel: `/admin`
     - Health check: `/healthz`
     - Config is persisted at `/data/config.json` (mounted volume)
+    - `BUILD_VERSION` is optional; when omitted, Docker build falls back to the repo `VERSION` file automatically
 
     ## First-time setup
     1. Open your service URL, then visit `/admin`


### PR DESCRIPTION
## 摘要
这次修改修复了 Zeabur 和普通 `docker build` 场景下的一处构建兼容性问题。

当前 `Dockerfile` 的 `go-builder` 阶段启用了 `set -u`，但在版本回退逻辑生效前就直接展开了 `${BUILD_VERSION}`。当部署平台没有显式传入这个 build arg 时，shell 会直接报 `BUILD_VERSION: parameter not set`，导致构建失败。

这次改动把 `BUILD_VERSION` 的读取改成了安全缺省展开，保持现有版本优先级不变：

- 优先使用显式传入的 `BUILD_VERSION`
- 未传入时回退到仓库根目录的 `VERSION` 文件
- 两者都没有时允许继续构建

同时补充了中英文部署文档和 `zeabur.yaml` 模板说明，明确 `BUILD_VERSION` 在 Zeabur / 普通 Docker 构建里是可选的。

## 变更内容
- 将 Docker 构建阶段中的 `BUILD_VERSION_RESOLVED="${BUILD_VERSION}"` 调整为安全缺省展开
- 保留现有的 `VERSION` 文件回退逻辑和显式 build arg 优先级
- 更新 `README`、`DEPLOY` 和 `zeabur.yaml` 中关于 Zeabur / Docker 构建版本来源的说明

## 验证情况
- 已验证在 `set -u` 下，`BUILD_VERSION` 未定义时不会再触发 shell 退出
- 已验证显式传入 `BUILD_VERSION` 时仍然保持原有优先级
- 已执行 `git diff --check`

当前运行环境没有安装 `docker` 和 `go`，所以这边没法直接补跑完整的 Docker 构建和 Go 单测；这一点在这里一并说明。