### PR TITLE
Preserve file-backed account tokens on startup and add regression test

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/base64"
+	"os"
 	"testing"
 )
 
@@ -47,6 +48,33 @@ func TestLoadStoreDropsLegacyTokenOnlyAccounts(t *testing.T) {
 	}
 	if accounts[0].Token != "" {
 		t.Fatalf("expected persisted token to be cleared, got %q", accounts[0].Token)
+	}
+}
+
+func TestLoadStorePreservesFileBackedTokensForRuntime(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "config-*.json")
+	if err != nil {
+		t.Fatalf("create temp config: %v", err)
+	}
+	defer tmp.Close()
+
+	if _, err := tmp.WriteString(`{
+		"accounts":[{"email":"u@example.com","password":"p","token":"persisted-token"}]
+	}`); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	t.Setenv("DS2API_CONFIG_JSON", "")
+	t.Setenv("CONFIG_JSON", "")
+	t.Setenv("DS2API_CONFIG_PATH", tmp.Name())
+
+	store := LoadStore()
+	accounts := store.Accounts()
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	if accounts[0].Token != "persisted-token" {
+		t.Fatalf("expected file-backed token preserved for runtime use, got %q", accounts[0].Token)
 	}
 }
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -57,7 +57,6 @@ func loadConfig() (Config, bool, error) {
 	if err := json.Unmarshal(content, &cfg); err != nil {
 		return Config{}, false, err
 	}
-	cfg.ClearAccountTokens()
 	cfg.DropInvalidAccounts()
 	if IsVercel() {
 		// Vercel filesystem is ephemeral/read-only for runtime writes; avoid save errors.


### PR DESCRIPTION
### Motivation
- Fix a startup regression where calling `cfg.ClearAccountTokens()` for file-backed `config.json` forced immediate re-login and triggered writes from `UpdateAccountToken`, which caused failures in read-only config deployments.

### Description
- Stop clearing account tokens when loading `config.json` from disk while retaining token clearing for env-provided configs parsed from `DS2API_CONFIG_JSON` so file-backed runtime tokens remain available after restart.
- Add `TestLoadStorePreservesFileBackedTokensForRuntime` in `internal/config/config_test.go` to assert a persisted token written to a temp `config.json` is preserved by `LoadStore()` for runtime use.

### Testing
- Executed `go test ./internal/config` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be45f9cff0832681b3199affed4613)