### PR TITLE
Docs: add `auto_delete.sessions`, rename `claude_model_mapping` to `claude_mapping`, and clarify config token handling

### DIFF
--- a/API.en.md
+++ b/API.en.md
@@ -623,6 +623,7 @@ Reads runtime settings and status, including:
 - `admin` (JWT expiry, default-password warning, etc.)
 - `runtime` (`account_max_inflight`, `account_max_queue`, `global_max_inflight`)
 - `toolcall` / `responses` / `embeddings`
+- `auto_delete` (`sessions`)
 - `claude_mapping` / `model_aliases`
 - `env_backed`, `needs_vercel_sync`
 
@@ -635,6 +636,7 @@ Hot-updates runtime settings. Supported fields:
 - `toolcall.mode` / `toolcall.early_emit_confidence`
 - `responses.store_ttl_seconds`
 - `embeddings.provider`
+- `auto_delete.sessions`
 - `claude_mapping`
 - `model_aliases`
 

--- a/API.md
+++ b/API.md
@@ -628,6 +628,7 @@ data: {"type":"message_stop"}
 - `admin`（JWT 过期、默认密码告警等）
 - `runtime`（`account_max_inflight`、`account_max_queue`、`global_max_inflight`）
 - `toolcall` / `responses` / `embeddings`
+- `auto_delete`（`sessions`）
 - `claude_mapping` / `model_aliases`
 - `env_backed`、`needs_vercel_sync`
 
@@ -640,6 +641,7 @@ data: {"type":"message_stop"}
 - `toolcall.mode` / `toolcall.early_emit_confidence`
 - `responses.store_ttl_seconds`
 - `embeddings.provider`
+- `auto_delete.sessions`
 - `claude_mapping`
 - `model_aliases`
 

--- a/README.MD
+++ b/README.MD
@@ -244,13 +244,11 @@ cp opencode.json.example opencode.json
   "accounts": [
     {
       "email": "user@example.com",
-      "password": "your-password",
-      "token": ""
+      "password": "your-password"
     },
     {
       "mobile": "12345678901",
-      "password": "your-password",
-      "token": ""
+      "password": "your-password"
     }
   ],
   "model_aliases": {
@@ -271,7 +269,7 @@ cp opencode.json.example opencode.json
   "embeddings": {
     "provider": "deterministic"
   },
-  "claude_model_mapping": {
+  "claude_mapping": {
     "fast": "deepseek-chat",
     "slow": "deepseek-reasoner"
   },
@@ -282,21 +280,25 @@ cp opencode.json.example opencode.json
     "account_max_inflight": 2,
     "account_max_queue": 0,
     "global_max_inflight": 0
+  },
+  "auto_delete": {
+    "sessions": false
   }
 }
 ```
 
 - `keys`：API 访问密钥列表，客户端通过 `Authorization: Bearer <key>` 鉴权
 - `accounts`：DeepSeek 账号列表，支持 `email` 或 `mobile` 登录
-- `token`：留空则首次请求时自动登录获取；也可预填已有 token
+- `token`：配置文件中即使填写也会在加载时被清空（不会从 `config.json` 读取 token）；实际 token 仅在运行时内存中维护并自动刷新
 - `model_aliases`：常见模型名（如 GPT/Codex/Claude）到 DeepSeek 模型的映射
 - `compat.wide_input_strict_output`：建议保持 `true`（当前实现默认宽进严出）
 - `toolcall`：固定采用特征匹配 + 高置信早发策略
 - `responses.store_ttl_seconds`：`/v1/responses/{id}` 的内存缓存 TTL
 - `embeddings.provider`：embedding 提供方（当前内置 `deterministic/mock/builtin`）
-- `claude_model_mapping`：字典中 `fast`/`slow` 后缀映射到对应 DeepSeek 模型
+- `claude_mapping`：字典中 `fast`/`slow` 后缀映射到对应 DeepSeek 模型（兼容读取 `claude_model_mapping`）
 - `admin`：管理后台设置（JWT 过期时间、密码哈希等），可通过 Admin Settings API 热更新
-- `runtime`：运行时参数（并发限制、队列大小），可通过 Admin Settings API 热更新
+- `runtime`：运行时参数（并发限制、队列大小），可通过 Admin Settings API 热更新；`account_max_queue=0`/`global_max_inflight=0` 表示按推荐值自动计算
+- `auto_delete.sessions`：是否在请求结束后自动清理 DeepSeek 会话（默认 `false`，可在 Settings 热更新）
 
 ### 环境变量
 

--- a/README.en.md
+++ b/README.en.md
@@ -244,13 +244,11 @@ cp opencode.json.example opencode.json
   "accounts": [
     {
       "email": "user@example.com",
-      "password": "your-password",
-      "token": ""
+      "password": "your-password"
     },
     {
       "mobile": "12345678901",
-      "password": "your-password",
-      "token": ""
+      "password": "your-password"
     }
   ],
   "model_aliases": {
@@ -271,7 +269,7 @@ cp opencode.json.example opencode.json
   "embeddings": {
     "provider": "deterministic"
   },
-  "claude_model_mapping": {
+  "claude_mapping": {
     "fast": "deepseek-chat",
     "slow": "deepseek-reasoner"
   },
@@ -282,21 +280,25 @@ cp opencode.json.example opencode.json
     "account_max_inflight": 2,
     "account_max_queue": 0,
     "global_max_inflight": 0
+  },
+  "auto_delete": {
+    "sessions": false
   }
 }
 ```
 
 - `keys`: API access keys; clients authenticate via `Authorization: Bearer <key>`
 - `accounts`: DeepSeek account list, supports `email` or `mobile` login
-- `token`: Leave empty for auto-login on first request; or pre-fill an existing token
+- `token`: Even if set in `config.json`, it is cleared during load (DS2API does not read persisted tokens from config); runtime tokens are maintained/refreshed in memory only
 - `model_aliases`: Map common model names (GPT/Codex/Claude) to DeepSeek models
 - `compat.wide_input_strict_output`: Keep `true` (current default policy)
 - `toolcall`: Fixed to feature matching + high-confidence early emit
 - `responses.store_ttl_seconds`: In-memory TTL for `/v1/responses/{id}`
 - `embeddings.provider`: Embeddings provider (`deterministic/mock/builtin` built-in)
-- `claude_model_mapping`: Maps `fast`/`slow` suffixes to corresponding DeepSeek models
+- `claude_mapping`: Maps `fast`/`slow` suffixes to corresponding DeepSeek models (still compatible with `claude_model_mapping`)
 - `admin`: Admin panel settings (JWT expiry, password hash, etc.), hot-reloadable via Admin Settings API
-- `runtime`: Runtime parameters (concurrency limits, queue sizes), hot-reloadable via Admin Settings API
+- `runtime`: Runtime parameters (concurrency limits, queue sizes), hot-reloadable via Admin Settings API; `account_max_queue=0`/`global_max_inflight=0` means auto-calculate from recommended values
+- `auto_delete.sessions`: Whether to auto-delete DeepSeek sessions after request completion (default `false`, hot-reloadable via Settings)
 
 ### Environment Variables
 

--- a/config.example.json
+++ b/config.example.json
@@ -9,20 +9,17 @@
     {
       "_comment": "邮箱登录方式",
       "email": "example1@example.com",
-      "password": "your-password-1",
-      "token": ""
+      "password": "your-password-1"
     },
     {
       "_comment": "邮箱登录方式 - 账号2",
       "email": "example2@example.com",
-      "password": "your-password-2",
-      "token": ""
+      "password": "your-password-2"
     },
     {
       "_comment": "手机号登录方式（中国大陆）",
       "mobile": "12345678901",
-      "password": "your-password-3",
-      "token": ""
+      "password": "your-password-3"
     }
   ],
   "model_aliases": {
@@ -43,8 +40,19 @@
   "embeddings": {
     "provider": "deterministic"
   },
-  "claude_model_mapping": {
+  "claude_mapping": {
     "fast": "deepseek-chat",
     "slow": "deepseek-reasoner"
+  },
+  "admin": {
+    "jwt_expire_hours": 24
+  },
+  "runtime": {
+    "account_max_inflight": 2,
+    "account_max_queue": 0,
+    "global_max_inflight": 0
+  },
+  "auto_delete": {
+    "sessions": false
   }
 }


### PR DESCRIPTION
### Motivation

- Document a new runtime option to control automatic DeepSeek session cleanup and make it adjustable via Admin Settings. 
- Standardize the Claude model mapping key and clarify compatibility with previous names. 
- Remove confusing `token` examples from config and explain that runtime tokens are not persisted in `config.json`.

### Description

- Added `auto_delete`/`auto_delete.sessions` to `GET /admin/settings` and `PUT /admin/settings` in `API.en.md` and `API.md` to expose the new setting. 
- Replaced `claude_model_mapping` with `claude_mapping` across `README.MD`, `README.en.md`, and `config.example.json` while documenting backward compatibility for the old name via reading compatibility. 
- Removed `token` fields from the example `accounts` entries and added a note that any `token` in `config.json` is cleared on load and runtime tokens are kept/refreshed in memory only. 
- Updated `config.example.json` and README files to include `admin` and `runtime` defaults and to document `auto_delete.sessions` with its default value `false` and runtime hot-reloadability.

### Testing

- This is a documentation and config-example change only and did not include automated tests. 
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be464ae7bc8326a2092b58e1b71229)