### PR TITLE
[Follow-up] Preserve empty tool completion turns in OpenAI prompt normalization

### DIFF
--- a/internal/adapter/openai/message_normalize.go
+++ b/internal/adapter/openai/message_normalize.go
@@ -29,7 +29,7 @@ func normalizeOpenAIMessagesForPrompt(raw []any, traceID string) []map[string]an
 		case "tool", "function":
 			content := normalizeOpenAIContentForPrompt(msg["content"])
 			if content == "" {
-				continue
+				content = "null"
 			}
 			out = append(out, map[string]any{
 				"role":    "user",

--- a/internal/adapter/openai/message_normalize_test.go
+++ b/internal/adapter/openai/message_normalize_test.go
@@ -117,6 +117,33 @@ func TestNormalizeOpenAIMessagesForPrompt_FunctionRoleCompatible(t *testing.T) {
 	}
 }
 
+func TestNormalizeOpenAIMessagesForPrompt_EmptyToolContentPreservedAsNull(t *testing.T) {
+	raw := []any{
+		map[string]any{
+			"role":         "tool",
+			"tool_call_id": "call_5",
+			"name":         "noop_tool",
+			"content":      "",
+		},
+		map[string]any{
+			"role":    "assistant",
+			"content": "done",
+		},
+	}
+
+	normalized := normalizeOpenAIMessagesForPrompt(raw, "")
+	if len(normalized) != 2 {
+		t.Fatalf("expected tool completion turn to be preserved, got %#v", normalized)
+	}
+	if normalized[0]["role"] != "user" {
+		t.Fatalf("expected tool role mapped to user, got %#v", normalized[0]["role"])
+	}
+	got, _ := normalized[0]["content"].(string)
+	if got != "null" {
+		t.Fatalf("expected empty tool content to be preserved as null placeholder, got %q", got)
+	}
+}
+
 func TestNormalizeOpenAIMessagesForPrompt_AssistantMultipleToolCallsRemainSeparated(t *testing.T) {
 	raw := []any{
 		map[string]any{


### PR DESCRIPTION
### Motivation
- A recent normalization change dropped `tool`/`function` messages when their normalized `content` was empty, which removes the signal that a tool call completed and can trigger repeated tool calls or missing final answers.

### Description
- Restore preservation of `tool`/`function` turns in `normalizeOpenAIMessagesForPrompt` by emitting a `"null"` placeholder when `normalizeOpenAIContentForPrompt` returns an empty string for those roles instead of skipping the message.
- Keep `tool`/`function` messages mapped to the `user` role as before so tool results remain part of the prompt stream.
- Add a regression unit test `TestNormalizeOpenAIMessagesForPrompt_EmptyToolContentPreservedAsNull` in `internal/adapter/openai/message_normalize_test.go` that verifies empty tool output is preserved as the `"null"` placeholder.

### Testing
- Ran `go test ./internal/adapter/openai` and the package tests passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bed1a7ca288326bd0b5267240362a5)