### PR TITLE
Fix raw tool-call JSON leaks when feature_match mode is off

### DIFF
--- a/internal/adapter/openai/handler_chat.go
+++ b/internal/adapter/openai/handler_chat.go
@@ -128,8 +128,8 @@ func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, resp *htt
 	}
 
 	created := time.Now().Unix()
-	bufferToolContent := len(toolNames) > 0 && h.toolcallFeatureMatchEnabled()
-	emitEarlyToolDeltas := h.toolcallEarlyEmitHighConfidence()
+	bufferToolContent := len(toolNames) > 0
+	emitEarlyToolDeltas := h.toolcallFeatureMatchEnabled() && h.toolcallEarlyEmitHighConfidence()
 	initialType := "text"
 	if thinkingEnabled {
 		initialType = "thinking"

--- a/internal/adapter/openai/responses_handler.go
+++ b/internal/adapter/openai/responses_handler.go
@@ -146,8 +146,8 @@ func (h *Handler) handleResponsesStream(w http.ResponseWriter, r *http.Request, 
 	if thinkingEnabled {
 		initialType = "thinking"
 	}
-	bufferToolContent := len(toolNames) > 0 && h.toolcallFeatureMatchEnabled()
-	emitEarlyToolDeltas := h.toolcallEarlyEmitHighConfidence()
+	bufferToolContent := len(toolNames) > 0
+	emitEarlyToolDeltas := h.toolcallFeatureMatchEnabled() && h.toolcallEarlyEmitHighConfidence()
 
 	streamRuntime := newResponsesStreamRuntime(
 		w,

--- a/internal/js/chat-stream/toolcall_policy.js
+++ b/internal/js/chat-stream/toolcall_policy.js
@@ -10,10 +10,10 @@ function resolveToolcallPolicy(prepBody, payloadTools) {
   const preparedToolNames = normalizePreparedToolNames(prepBody && prepBody.tool_names);
   const toolNames = preparedToolNames.length > 0 ? preparedToolNames : extractToolNames(payloadTools);
   const featureMatchEnabled = boolDefaultTrue(prepBody && prepBody.toolcall_feature_match);
-  const emitEarlyToolDeltas = boolDefaultTrue(prepBody && prepBody.toolcall_early_emit_high);
+  const emitEarlyToolDeltas = featureMatchEnabled && boolDefaultTrue(prepBody && prepBody.toolcall_early_emit_high);
   return {
     toolNames,
-    toolSieveEnabled: toolNames.length > 0 && featureMatchEnabled,
+    toolSieveEnabled: toolNames.length > 0,
     emitEarlyToolDeltas,
   };
 }

--- a/tests/node/chat-stream.test.js
+++ b/tests/node/chat-stream.test.js
@@ -44,7 +44,7 @@ test('resolveToolcallPolicy respects prepare flags and prepared tool names', () 
     [{ type: 'function', function: { name: 'fallback_tool', parameters: { type: 'object' } } }],
   );
   assert.deepEqual(policy.toolNames, ['prepped_tool']);
-  assert.equal(policy.toolSieveEnabled, false);
+  assert.equal(policy.toolSieveEnabled, true);
   assert.equal(policy.emitEarlyToolDeltas, false);
 });
 


### PR DESCRIPTION
### Motivation
- When `toolcall_feature_match` was disabled the stream sieve/buffering was also disabled, allowing raw `{"tool_calls": ...}` JSON to be emitted as assistant content and leak to clients before being parsed as tool calls.
- The goal is to prevent visible JSON/tool-call leaks while preserving the intended difference in early incremental emission behavior controlled by `feature_match` and confidence settings.

### Description
- Always enable stream tool-content buffering/sieve when `toolNames` are present by making `toolSieveEnabled` / `bufferToolContent` depend only on `len(toolNames) > 0` (Node: `internal/js/chat-stream/toolcall_policy.js`, Go: `internal/adapter/openai/handler_chat.go` and `internal/adapter/openai/responses_handler.go`).
- Keep early incremental tool-delta emission gated by feature-match and confidence by setting `emitEarlyToolDeltas` = `featureMatch && early_emit` (Node) and `emitEarlyToolDeltas` = `h.toolcallFeatureMatchEnabled() && h.toolcallEarlyEmitHighConfidence()` (Go).
- Update the Node unit test expectation in `tests/node/chat-stream.test.js` to reflect that sieve stays enabled even when `toolcall_feature_match` is false.

### Testing
- Ran Node unit tests with `node --test tests/node/chat-stream.test.js tests/node/stream-tool-sieve.test.js`, all tests passed (42 tests, 0 failures).
- Ran Go tests with `go test ./internal/adapter/openai/...`, which succeeded (`ok ds2api/internal/adapter/openai`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bed98961e8832695aaf60bcb985af9)