### PR TITLE
修复 env 写回模式回退 & 收紧 CONTENT_FILTER 裁剪

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,6 +154,39 @@ func TestEnvBackedStoreWritebackDoesNotBootstrapOnInvalidEnvJSON(t *testing.T) {
 	}
 }
 
+func TestEnvBackedStoreWritebackFallsBackToPersistedFileWhenEnvMalformed(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "config-*.json")
+	if err != nil {
+		t.Fatalf("create temp config: %v", err)
+	}
+	path := tmp.Name()
+	_ = tmp.Close()
+
+	seed := `{"keys":["file-k"],"accounts":[{"email":"file@example.com","password":"p"}]}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("write seed config: %v", err)
+	}
+
+	t.Setenv("DS2API_CONFIG_JSON", "{invalid-json")
+	t.Setenv("CONFIG_JSON", "")
+	t.Setenv("DS2API_CONFIG_PATH", path)
+	t.Setenv("DS2API_ENV_WRITEBACK", "1")
+
+	cfg, fromEnv, loadErr := loadConfig()
+	if loadErr == nil {
+		t.Fatalf("expected loadConfig error for invalid env json")
+	}
+	if fromEnv {
+		t.Fatalf("expected fromEnv=false when persisted config file fallback succeeds")
+	}
+	if len(cfg.Keys) != 1 || cfg.Keys[0] != "file-k" {
+		t.Fatalf("expected keys from persisted file, got %#v", cfg.Keys)
+	}
+	if len(cfg.Accounts) != 1 || cfg.Accounts[0].Email != "file@example.com" {
+		t.Fatalf("expected accounts from persisted file, got %#v", cfg.Accounts)
+	}
+}
+
 func TestRuntimeTokenRefreshIntervalHoursDefaultsToSix(t *testing.T) {
 	t.Setenv("DS2API_CONFIG_JSON", `{
 		"keys":["k1"],

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -41,6 +41,17 @@ func loadConfig() (Config, bool, error) {
 	if rawCfg != "" {
 		cfg, err := parseConfigString(rawCfg)
 		if err != nil {
+			if IsVercel() || !envWritebackEnabled() {
+				return cfg, true, err
+			}
+			content, fileErr := os.ReadFile(ConfigPath())
+			if fileErr == nil {
+				var fileCfg Config
+				if unmarshalErr := json.Unmarshal(content, &fileCfg); unmarshalErr == nil {
+					fileCfg.DropInvalidAccounts()
+					return fileCfg, false, err
+				}
+			}
 			return cfg, true, err
 		}
 		cfg.ClearAccountTokens()

--- a/internal/sse/content_filter_leak.go
+++ b/internal/sse/content_filter_leak.go
@@ -2,6 +2,13 @@ package sse
 
 import "strings"
 
+var leakedContentFilterSuffixPrefixes = []string{
+	"你好，这个问题我暂时无法回答",
+	"您好，这个问题我暂时无法回答",
+	"，这个问题我暂时无法回答",
+	",这个问题我暂时无法回答",
+}
+
 func filterLeakedContentFilterParts(parts []ContentPart) []ContentPart {
 	if len(parts) == 0 {
 		return parts
@@ -22,9 +29,26 @@ func stripLeakedContentFilterSuffix(text string) string {
 	if text == "" {
 		return text
 	}
-	idx := strings.Index(strings.ToUpper(text), "CONTENT_FILTER")
+	upper := strings.ToUpper(text)
+	idx := strings.Index(upper, "CONTENT_FILTER")
 	if idx < 0 {
 		return text
 	}
+	suffix := strings.TrimSpace(text[idx+len("CONTENT_FILTER"):])
+	if !looksLikeLeakedContentFilterSuffix(suffix) {
+		return text
+	}
 	return strings.TrimRight(text[:idx], " \t\r\n")
+}
+
+func looksLikeLeakedContentFilterSuffix(suffix string) bool {
+	if suffix == "" {
+		return false
+	}
+	for _, p := range leakedContentFilterSuffixPrefixes {
+		if strings.HasPrefix(suffix, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sse/line_test.go
+++ b/internal/sse/line_test.go
@@ -55,3 +55,13 @@ func TestParseDeepSeekContentLineDropsPureLeakedContentFilterChunk(t *testing.T)
 		t.Fatalf("expected empty parts, got %#v", res.Parts)
 	}
 }
+
+func TestParseDeepSeekContentLineKeepsLegitContentFilterMentions(t *testing.T) {
+	res := ParseDeepSeekContentLine([]byte(`data: {"p":"response/content","v":"字符串 CONTENT_FILTER 用于说明上游审核信号"}`), false, "text")
+	if !res.Parsed || res.Stop {
+		t.Fatalf("expected parsed non-stop result: %#v", res)
+	}
+	if len(res.Parts) != 1 || res.Parts[0].Text != "字符串 CONTENT_FILTER 用于说明上游审核信号" {
+		t.Fatalf("unexpected parts for legit mention: %#v", res.Parts)
+	}
+}


### PR DESCRIPTION
### Motivation
- 修复 `loadConfig` 在写回（env writeback）模式下的早退问题：当环境变量 `DS2API_CONFIG_JSON`/`CONFIG_JSON` 存在但解析失败时，应回退到磁盘上的持久化配置以维持 file-backed 行为，避免重启后丢失 keys/accounts。 
- 避免对任意包含 `CONTENT_FILTER` 的文本无差别截断，只有确认为上游泄漏签名时才裁剪，以免破坏正常可见内容（例如对审查机制的说明）。

### Description
- 在 `loadConfig` 中，当 `DS2API_CONFIG_JSON`/`CONFIG_JSON` 无法解析时增加逻辑：若非 Vercel 且允许写回，则尝试读取 `ConfigPath()` 指向的持久化文件并在可解析时返回该文件配置（并将 `fromEnv=false`）。
- 在 `internal/sse/content_filter_leak.go` 中收紧裁剪逻辑：搜索到 `CONTENT_FILTER` 后仅在其后缀匹配已知泄漏签名（例如中文“你好，这个问题我暂时无法回答”之类前缀）时才从文本中去除该后缀，否则保留原文。 
- 新增/更新回归测试：`TestEnvBackedStoreWritebackFallsBackToPersistedFileWhenEnvMalformed` 覆盖 env JSON 畸形但磁盘配置可用的回退场景，以及 `TestParseDeepSeekContentLineKeepsLegitContentFilterMentions` 验证合法提及 `CONTENT_FILTER` 不被误截断。 
- 修改的文件：`internal/config/store.go`、`internal/config/config_test.go`、`internal/sse/content_filter_leak.go`、`internal/sse/line_test.go`。

### Testing
- 运行了 `go test ./internal/config ./internal/sse`，两组测试均通过。 
- 新增的单元测试 `TestEnvBackedStoreWritebackFallsBackToPersistedFileWhenEnvMalformed` 和 `TestParseDeepSeekContentLineKeepsLegitContentFilterMentions` 已在本地测试套件中通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa782612c832db5a9862901b04fef)