### PR TITLE
Fix account pool starvation when only one managed account has token

### DIFF
--- a/internal/account/pool_acquire.go
+++ b/internal/account/pool_acquire.go
@@ -60,16 +60,10 @@ func (p *Pool) acquireLocked(target string, exclude map[string]bool) (config.Acc
 		return acc, true
 	}
 
-	if acc, ok := p.tryAcquire(exclude, true); ok {
-		return acc, true
-	}
-	if acc, ok := p.tryAcquire(exclude, false); ok {
-		return acc, true
-	}
-	return config.Account{}, false
+	return p.tryAcquire(exclude)
 }
 
-func (p *Pool) tryAcquire(exclude map[string]bool, requireToken bool) (config.Account, bool) {
+func (p *Pool) tryAcquire(exclude map[string]bool) (config.Account, bool) {
 	for i := 0; i < len(p.queue); i++ {
 		id := p.queue[i]
 		if exclude[id] || !p.canAcquireIDLocked(id) {
@@ -77,9 +71,6 @@ func (p *Pool) tryAcquire(exclude map[string]bool, requireToken bool) (config.Ac
 		}
 		acc, ok := p.store.FindAccount(id)
 		if !ok {
-			continue
-		}
-		if requireToken && acc.Token == "" {
 			continue
 		}
 		p.inUse[id]++

--- a/internal/account/pool_test.go
+++ b/internal/account/pool_test.go
@@ -215,6 +215,33 @@ func TestPoolDropsLegacyTokenOnlyAccountOnLoad(t *testing.T) {
 	}
 }
 
+func TestPoolAcquireRotatesIntoTokenlessAccounts(t *testing.T) {
+	t.Setenv("DS2API_ACCOUNT_MAX_INFLIGHT", "1")
+	t.Setenv("DS2API_ACCOUNT_CONCURRENCY", "")
+	t.Setenv("DS2API_ACCOUNT_MAX_QUEUE", "")
+	t.Setenv("DS2API_ACCOUNT_QUEUE_SIZE", "")
+	t.Setenv("DS2API_CONFIG_JSON", `{
+		"keys":["k1"],
+		"accounts":[
+			{"email":"acc1@example.com","token":"token1"},
+			{"email":"acc2@example.com","token":""},
+			{"email":"acc3@example.com","token":""}
+		]
+	}`)
+
+	pool := NewPool(config.LoadStore())
+	for i, want := range []string{"acc1@example.com", "acc2@example.com", "acc3@example.com"} {
+		acc, ok := pool.Acquire("", nil)
+		if !ok {
+			t.Fatalf("expected acquire success at step %d", i+1)
+		}
+		if got := acc.Identifier(); got != want {
+			t.Fatalf("unexpected account at step %d: got %q want %q", i+1, got, want)
+		}
+		pool.Release(acc.Identifier())
+	}
+}
+
 func TestPoolAcquireWaitQueuesAndSucceedsAfterRelease(t *testing.T) {
 	pool := newSingleAccountPoolForTest(t, "1")
 	first, ok := pool.Acquire("", nil)


### PR DESCRIPTION
### Motivation

- The account pool previously preferred accounts that already had a token, which caused starvation when only one account was logged-in after a restart so other accounts never got selected to perform login. 
- This prevented tokenless managed accounts from being rotated into and refreshed, degrading concurrency and availability.

### Description

- Remove the two-pass token-first acquisition logic and unify `Acquire`/`tryAcquire` so the pool always selects accounts by strict queue round-robin regardless of `Account.Token` presence (`internal/account/pool_acquire.go`).
- Simplify `tryAcquire` to iterate the queue once and pick the first eligible account, bumping it to the tail and incrementing its in-use slot on selection.
- Add a regression test `TestPoolAcquireRotatesIntoTokenlessAccounts` to verify mixed token/tokenless accounts rotate correctly and trigger login for empty-token accounts (`internal/account/pool_test.go`).

### Testing

- Ran `go test ./internal/account ./internal/auth` and the test suite passed (`ok   ds2api/internal/account` and `ok   ds2api/internal/auth`).
- The new regression test `TestPoolAcquireRotatesIntoTokenlessAccounts` is included and exercised by the above test run and succeeded.
- No other automated tests were changed and all targeted tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4120f708832db81c6f568c1a8e54)