### PR TITLE
Fix tool sieve regression for loose `functionCall` keys

### DIFF
--- a/internal/adapter/openai/tool_sieve_functioncall.go
+++ b/internal/adapter/openai/tool_sieve_functioncall.go
@@ -4,7 +4,22 @@ import "strings"
 
 func findQuotedFunctionCallKeyStart(s string) int {
 	lower := strings.ToLower(s)
-	const key = "\"functioncall\""
+	quotedIdx := findFunctionCallKeyStart(lower, `"functioncall"`)
+	baretIdx := findFunctionCallKeyStart(lower, "functioncall")
+
+	switch {
+	case quotedIdx < 0:
+		return baretIdx
+	case baretIdx < 0:
+		return quotedIdx
+	case quotedIdx < baretIdx:
+		return quotedIdx
+	default:
+		return baretIdx
+	}
+}
+
+func findFunctionCallKeyStart(lower, key string) int {
 	for from := 0; from < len(lower); {
 		rel := strings.Index(lower[from:], key)
 		if rel < 0 {
@@ -12,6 +27,10 @@ func findQuotedFunctionCallKeyStart(s string) int {
 		}
 		idx := from + rel
 		if !hasJSONObjectContextPrefix(lower[:idx]) {
+			from = idx + 1
+			continue
+		}
+		if !hasJSONKeyBoundary(lower, idx, len(key)) {
 			from = idx + 1
 			continue
 		}
@@ -29,4 +48,24 @@ func findQuotedFunctionCallKeyStart(s string) int {
 
 func hasJSONObjectContextPrefix(prefix string) bool {
 	return strings.LastIndex(prefix, "{") >= 0
+}
+
+func hasJSONKeyBoundary(s string, idx, keyLen int) bool {
+	if idx > 0 {
+		prev := s[idx-1]
+		if isLowerAlphaNumeric(prev) {
+			return false
+		}
+	}
+	if end := idx + keyLen; end < len(s) {
+		next := s[end]
+		if isLowerAlphaNumeric(next) {
+			return false
+		}
+	}
+	return true
+}
+
+func isLowerAlphaNumeric(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_'
 }

--- a/internal/adapter/openai/tool_sieve_xml_test.go
+++ b/internal/adapter/openai/tool_sieve_xml_test.go
@@ -135,6 +135,21 @@ func TestFindToolSegmentStartDetectsQuotedFunctionCallKey(t *testing.T) {
 	}
 }
 
+func TestFindToolSegmentStartDetectsLooseFunctionCallKey(t *testing.T) {
+	input := `prefix {functionCall: {"name":"search_web","args":{"query":"x"}}}`
+	want := strings.Index(input, "{")
+	if got := findToolSegmentStart(input); got != want {
+		t.Fatalf("expected JSON object start %d, got %d", want, got)
+	}
+}
+
+func TestFindToolSegmentStartIgnoresLooseFunctionCallProse(t *testing.T) {
+	input := "Please explain why functionCall: is used in documentation examples."
+	if got := findToolSegmentStart(input); got != -1 {
+		t.Fatalf("expected no tool segment start for prose, got %d", got)
+	}
+}
+
 func TestProcessToolSieveDoesNotBufferFunctionCallProse(t *testing.T) {
 	var state toolStreamSieveState
 	chunk := "Please explain the functionCall API field and keep streaming this sentence."


### PR DESCRIPTION
### Motivation

- A regression caused the tool-sieve to only match the quoted key `"functionCall"`, so loose outputs like `{functionCall:{...}}` were no longer recognized and tool payloads leaked as plain text.

### Description

- Restore detection for both quoted and bare `functionCall` keys by checking both variants in `findQuotedFunctionCallKeyStart` and choosing the earliest valid match.
- Factored the search into `findFunctionCallKeyStart` and added `hasJSONKeyBoundary` and `isLowerAlphaNumeric` to require JSON-like key boundaries and avoid false positives in prose.
- Kept the existing protections by still verifying JSON context (`hasJSONObjectContextPrefix`) and requiring a trailing colon before accepting a key.
- Added unit tests `TestFindToolSegmentStartDetectsLooseFunctionCallKey` and `TestFindToolSegmentStartIgnoresLooseFunctionCallProse` to cover loose-key detection and ensure prose isn't misclassified; changed files: `internal/adapter/openai/tool_sieve_functioncall.go` and `internal/adapter/openai/tool_sieve_xml_test.go`.

### Testing

- Ran `go test ./internal/adapter/openai -run 'TestFindToolSegmentStart(DetectsLooseFunctionCallKey|DetectsQuotedFunctionCallKey|IgnoresLooseFunctionCallProse|IgnoresFunctionCallProse)' -count=1 -timeout 60s` and it passed.
- Ran full package tests with `go test ./internal/adapter/openai -count=1 -timeout 120s` and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce033c5088832d9e0a0abbdf19d17b)