### PR TITLE
Fix Claude mapping and Gemini proxy error envelope

### DIFF
--- a/internal/adapter/claude/handler_messages.go
+++ b/internal/adapter/claude/handler_messages.go
@@ -111,6 +111,13 @@ func (h *Handler) proxyViaOpenAI(w http.ResponseWriter, r *http.Request) bool {
 	}
 	model, _ := req["model"].(string)
 	stream := util.ToBool(req["stream"])
+	if norm, normErr := normalizeClaudeRequest(h.Store, req); normErr == nil {
+		model = norm.Standard.ResolvedModel
+		req["model"] = model
+		if encoded, encodeErr := json.Marshal(req); encodeErr == nil {
+			raw = encoded
+		}
+	}
 	translatedReq := translatorcliproxy.ToOpenAI(sdktranslator.FormatClaude, model, raw, stream)
 
 	isVercelPrepare := strings.TrimSpace(r.URL.Query().Get("__stream_prepare")) == "1"

--- a/internal/adapter/claude/proxy_vercel_test.go
+++ b/internal/adapter/claude/proxy_vercel_test.go
@@ -2,11 +2,18 @@ package claude
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+type claudeProxyStoreStub struct {
+	mapping map[string]string
+}
+
+func (s claudeProxyStoreStub) ClaudeMapping() map[string]string { return s.mapping }
 
 type openAIProxyStub struct {
 	status int
@@ -22,8 +29,27 @@ func (s openAIProxyStub) ChatCompletions(w http.ResponseWriter, _ *http.Request)
 	_, _ = w.Write([]byte(s.body))
 }
 
+type capturingOpenAIProxyStub struct {
+	status   int
+	body     string
+	lastBody []byte
+}
+
+func (s *capturingOpenAIProxyStub) ChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if s.status == 0 {
+		s.status = http.StatusOK
+	}
+	s.lastBody, _ = io.ReadAll(r.Body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(s.status)
+	_, _ = w.Write([]byte(s.body))
+}
+
 func TestClaudeProxyViaOpenAIVercelPreparePassthrough(t *testing.T) {
-	h := &Handler{OpenAI: openAIProxyStub{status: 200, body: `{"lease_id":"lease_123","payload":{"a":1}}`}}
+	h := &Handler{
+		Store:  claudeProxyStoreStub{mapping: map[string]string{"fast": "deepseek-chat", "slow": "deepseek-reasoner"}},
+		OpenAI: openAIProxyStub{status: 200, body: `{"lease_id":"lease_123","payload":{"a":1}}`},
+	}
 	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages?__stream_prepare=1", strings.NewReader(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hi"}],"stream":true}`))
 	rec := httptest.NewRecorder()
 
@@ -38,5 +64,32 @@ func TestClaudeProxyViaOpenAIVercelPreparePassthrough(t *testing.T) {
 	}
 	if _, ok := out["lease_id"]; !ok {
 		t.Fatalf("expected lease_id in prepare passthrough, got=%v", out)
+	}
+}
+
+func TestClaudeProxyViaOpenAIResolvesModelUsingClaudeMapping(t *testing.T) {
+	proxy := &capturingOpenAIProxyStub{status: 200, body: `{"id":"chatcmpl-1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`}
+	h := &Handler{
+		Store:  claudeProxyStoreStub{mapping: map[string]string{"fast": "deepseek-chat", "slow": "deepseek-reasoner"}},
+		OpenAI: proxy,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", strings.NewReader(`{"model":"claude-opus-4-1","messages":[{"role":"user","content":"hi"}],"max_tokens":64}`))
+	rec := httptest.NewRecorder()
+
+	h.Messages(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("expected json response, got err=%v body=%s", err, rec.Body.String())
+	}
+	var proxied map[string]any
+	if err := json.Unmarshal(proxy.lastBody, &proxied); err != nil {
+		t.Fatalf("expected proxied request json, got err=%v body=%s", err, string(proxy.lastBody))
+	}
+	if got, _ := proxied["model"].(string); got != "deepseek-reasoner" {
+		t.Fatalf("expected proxied model mapped to deepseek-reasoner, got %q proxied=%v response=%v", got, proxied, out)
 	}
 }

--- a/internal/adapter/gemini/handler_generate.go
+++ b/internal/adapter/gemini/handler_generate.go
@@ -139,13 +139,7 @@ func (h *Handler) proxyViaOpenAI(w http.ResponseWriter, r *http.Request, stream 
 	defer res.Body.Close()
 	body, _ := io.ReadAll(res.Body)
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		for k, vv := range res.Header {
-			for _, v := range vv {
-				w.Header().Add(k, v)
-			}
-		}
-		w.WriteHeader(res.StatusCode)
-		_, _ = w.Write(body)
+		writeGeminiError(w, res.StatusCode, extractProxyErrorMessage(body))
 		return true
 	}
 	if isVercelPrepare {
@@ -163,6 +157,23 @@ func (h *Handler) proxyViaOpenAI(w http.ResponseWriter, r *http.Request, stream 
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(converted)
 	return true
+}
+
+func extractProxyErrorMessage(body []byte) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return "Request failed."
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return trimmed
+	}
+	errObj, _ := parsed["error"].(map[string]any)
+	message, _ := errObj["message"].(string)
+	if strings.TrimSpace(message) != "" {
+		return strings.TrimSpace(message)
+	}
+	return trimmed
 }
 
 func (h *Handler) handleNonStreamGenerateContent(w http.ResponseWriter, resp *http.Response, model, finalPrompt string, thinkingEnabled bool, toolNames []string) {

--- a/internal/adapter/gemini/proxy_vercel_test.go
+++ b/internal/adapter/gemini/proxy_vercel_test.go
@@ -40,3 +40,26 @@ func TestGeminiProxyViaOpenAIVercelReleasePassthrough(t *testing.T) {
 		t.Fatalf("expected success=true passthrough, got=%v", out)
 	}
 }
+
+func TestGeminiProxyViaOpenAIConvertsErrorEnvelope(t *testing.T) {
+	h := &Handler{OpenAI: openAIProxyStub{status: http.StatusUnauthorized, body: `{"error":{"message":"invalid api key"}}`}}
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", strings.NewReader(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`))
+	rec := httptest.NewRecorder()
+
+	h.GenerateContent(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("expected json response, got err=%v body=%s", err, rec.Body.String())
+	}
+	errMap, _ := out["error"].(map[string]any)
+	if got, _ := errMap["status"].(string); got != "UNAUTHENTICATED" {
+		t.Fatalf("expected gemini-style status, got %q response=%v", got, out)
+	}
+	if got, _ := errMap["message"].(string); got != "invalid api key" {
+		t.Fatalf("expected extracted error message, got %q response=%v", got, out)
+	}
+}


### PR DESCRIPTION
### Motivation

- Preserve existing `claude_mapping` routing when Anthropic/Claude requests are proxied via the OpenAI path so deployments that rely on `fast`/`slow` mappings are not bypassed.
- Ensure Gemini routes maintain Gemini-style error envelopes instead of returning raw OpenAI-style errors when proxied calls fail to keep API compatibility for callers parsing `error.code/error.status`.
- Add regression tests to prevent future regressions for both the Claude model mapping and the Gemini error conversion behavior.

### Description

- In `internal/adapter/claude/handler_messages.go` call `normalizeClaudeRequest` before translating to OpenAI and set the request `model` to the normalized `ResolvedModel`, then re-encode the proxied body so upstream receives the mapped model.
- In `internal/adapter/gemini/handler_generate.go` convert non-2xx OpenAI proxy responses to Gemini-style errors by calling `writeGeminiError` with an extracted message from the upstream body via the new `extractProxyErrorMessage` helper.
- Added tests: `TestClaudeProxyViaOpenAIResolvesModelUsingClaudeMapping` to assert the proxied request uses the `slow` mapping and `TestGeminiProxyViaOpenAIConvertsErrorEnvelope` to assert Gemini-error shape and message extraction, and introduced small test helpers (`capturingOpenAIProxyStub` and `claudeProxyStoreStub`).

### Testing

- Ran `go test ./internal/adapter/claude ./internal/adapter/gemini` and both packages passed (`ok` for `claude` and `gemini`).
- Added unit tests exercise the new behavior and they passed locally as part of the test run.
- No other automated test suites were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea7fcc550832e94444fe30a751a88)