### PR TITLE
Bump Node and Go base images and add runtime baseline to Zeabur template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS webui-builder
+FROM node:24 AS webui-builder
 
 WORKDIR /app/webui
 COPY webui/package.json webui/package-lock.json ./
@@ -6,7 +6,7 @@ RUN npm ci
 COPY webui ./
 RUN npm run build
 
-FROM golang:1.24 AS go-builder
+FROM golang:1.26 AS go-builder
 WORKDIR /app
 ARG TARGETOS
 ARG TARGETARCH

--- a/zeabur.yaml
+++ b/zeabur.yaml
@@ -12,6 +12,9 @@ spec:
   readme: |-
     # DS2API (Zeabur)
 
+    ## Runtime baseline
+    - Go: 1.26
+
     ## After deployment
     - Admin panel: `/admin`
     - Health check: `/healthz`


### PR DESCRIPTION
### Motivation
- Update build/runtime toolchains to supported newer versions for compatibility and security.
- Surface the Go runtime baseline in the Zeabur template documentation to clarify the expected environment.

### Description
- Updated Dockerfile to use `node:24` for the web UI builder instead of `node:20`.
- Updated Dockerfile to use `golang:1.26` for the Go builder instead of `golang:1.24`.
- Added a `Runtime baseline` note (`Go: 1.26`) to the `readme` section of `zeabur.yaml` to document the required Go version.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceabc71d38832e9da4c680c0a0eb93)