### PR TITLE
tests: generate JSON request body in capture-raw-stream-sample.sh and use --data-binary

### DIFF
--- a/tests/scripts/capture-raw-stream-sample.sh
+++ b/tests/scripts/capture-raw-stream-sample.sh
@@ -47,11 +47,23 @@ for _ in $(seq 1 120); do
   sleep 1
 done
 
+REQUEST_BODY="$(python3 - <<'PY' "$MODEL" "$QUESTION"
+import json,sys
+model,question=sys.argv[1:3]
+payload={
+  'model':model,
+  'stream':True,
+  'messages':[{'role':'user','content':question}],
+}
+print(json.dumps(payload, ensure_ascii=False))
+PY
+)"
+
 curl -sS http://127.0.0.1:5001/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer ${API_KEY}" \
-  -d "{\"model\":\"${MODEL}\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"${QUESTION}\"}]}" \
-  >"${OUT_DIR}/openai.stream.sse" || true
+  --data-binary "${REQUEST_BODY}" \
+  >"${OUT_DIR}/openai.stream.sse"
 
 curl -sS http://127.0.0.1:5001/admin/dev/captures \
   -H "Authorization: Bearer ${ADMIN_KEY}" \


### PR DESCRIPTION
### Motivation

- Avoid brittle shell JSON quoting when posting streaming chat requests and ensure the raw request body is sent exactly as generated to the local test server.

### Description

- Create `REQUEST_BODY` via an inline `python3` helper that JSON-encodes the `model`, `stream`, and `messages` payload to avoid shell escaping issues. 
- Replace the inline `-d` JSON curl payload with `--data-binary "${REQUEST_BODY}"` so the request body is sent verbatim to the capture server. 
- Remove the previous curl `|| true` fallback and rely on the direct curl invocation to produce the streamed output file for capture processing.

### Testing

- Ran the script `tests/scripts/capture-raw-stream-sample.sh` against the local test server and verified it produced `openai.stream.sse`, `captures.json`, and `upstream.stream.sse` files; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf48f1bc588333aa247091b55bcbcc)