### PR TITLE
Preserve newline before leaked CONTENT_FILTER and make XML tool-call parsing more robust

### DIFF
--- a/internal/sse/content_filter_leak.go
+++ b/internal/sse/content_filter_leak.go
@@ -9,7 +9,7 @@ func filterLeakedContentFilterParts(parts []ContentPart) []ContentPart {
 	out := make([]ContentPart, 0, len(parts))
 	for _, p := range parts {
 		cleaned := stripLeakedContentFilterSuffix(p.Text)
-		if strings.TrimSpace(cleaned) == "" {
+		if shouldDropCleanedLeakedChunk(cleaned) {
 			continue
 		}
 		p.Text = cleaned
@@ -27,5 +27,19 @@ func stripLeakedContentFilterSuffix(text string) string {
 	if idx < 0 {
 		return text
 	}
-	return strings.TrimRight(text[:idx], " \t\r\n")
+	// Keep "\n" so we don't collapse line structure when the upstream model
+	// appends leaked CONTENT_FILTER markers after a line break.
+	return strings.TrimRight(text[:idx], " \t\r")
+}
+
+func shouldDropCleanedLeakedChunk(cleaned string) bool {
+	if cleaned == "" {
+		return true
+	}
+	// Preserve newline-only chunks to avoid dropping legitimate line breaks
+	// before a leaked CONTENT_FILTER suffix.
+	if strings.Contains(cleaned, "\n") {
+		return false
+	}
+	return strings.TrimSpace(cleaned) == ""
 }

--- a/internal/sse/line_test.go
+++ b/internal/sse/line_test.go
@@ -102,3 +102,23 @@ func TestParseDeepSeekContentLineContentTextEqualContentFilterDoesNotStop(t *tes
 		t.Fatalf("did not expect content-filter stop for content text: %#v", res)
 	}
 }
+
+func TestParseDeepSeekContentLinePreservesTrailingNewlineBeforeLeakedContentFilter(t *testing.T) {
+	res := ParseDeepSeekContentLine([]byte("data: {\"p\":\"response/content\",\"v\":\"line1\\nCONTENT_FILTERblocked\"}"), false, "text")
+	if !res.Parsed || res.Stop {
+		t.Fatalf("expected parsed non-stop result: %#v", res)
+	}
+	if len(res.Parts) != 1 || res.Parts[0].Text != "line1\n" {
+		t.Fatalf("expected trailing newline preserved, got %#v", res.Parts)
+	}
+}
+
+func TestParseDeepSeekContentLineKeepsNewlineOnlyChunkBeforeLeakedContentFilter(t *testing.T) {
+	res := ParseDeepSeekContentLine([]byte("data: {\"p\":\"response/content\",\"v\":\"\\nCONTENT_FILTERblocked\"}"), false, "text")
+	if !res.Parsed || res.Stop {
+		t.Fatalf("expected parsed non-stop result: %#v", res)
+	}
+	if len(res.Parts) != 1 || res.Parts[0].Text != "\n" {
+		t.Fatalf("expected newline-only chunk preserved, got %#v", res.Parts)
+	}
+}

--- a/internal/util/toolcalls_parse_markup.go
+++ b/internal/util/toolcalls_parse_markup.go
@@ -19,6 +19,12 @@ var toolUseFunctionPattern = regexp.MustCompile(`(?is)<tool_use>\s*<function\s+n
 var toolUseNameParametersPattern = regexp.MustCompile(`(?is)<tool_use>\s*<tool_name>\s*([^<]+?)\s*</tool_name>\s*<parameters>\s*(.*?)\s*</parameters>\s*</tool_use>`)
 var toolUseFunctionNameParametersPattern = regexp.MustCompile(`(?is)<tool_use>\s*<function_name>\s*([^<]+?)\s*</function_name>\s*<parameters>\s*(.*?)\s*</parameters>\s*</tool_use>`)
 var toolUseToolNameBodyPattern = regexp.MustCompile(`(?is)<tool_use>\s*<tool_name>\s*([^<]+?)\s*</tool_name>\s*(.*?)\s*</tool_use>`)
+var xmlToolCallNameTagNames = []string{"tool_name", "function_name", "name"}
+var xmlToolCallNamePatternByTag = map[string]*regexp.Regexp{
+	"tool_name":     regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?tool_name\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?tool_name>`),
+	"function_name": regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?function_name\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?function_name>`),
+	"name":          regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?name\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?name>`),
+}
 
 func parseXMLToolCalls(text string) []ParsedToolCall {
 	matches := xmlToolCallPattern.FindAllString(text, -1)
@@ -81,6 +87,22 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 		}
 	}
 
+	// First try regex-based extraction for <tool_name>/<parameters>.
+	// This is resilient to non-XML-safe characters (e.g. raw '&' in shell commands).
+	nameFromTags := findMarkupTagValue(inner, xmlToolCallNameTagNames, xmlToolCallNamePatternByTag)
+	if strings.TrimSpace(nameFromTags) != "" {
+		if argsRaw := findMarkupTagValue(inner, toolCallMarkupArgsTagNames, toolCallMarkupArgsPatternByTag); strings.TrimSpace(argsRaw) != "" {
+			if parsed := parseToolCallInput(argsRaw); len(parsed) > 0 {
+				if !(len(parsed) == 1 && parsed["_raw"] != nil) {
+					return ParsedToolCall{
+						Name:  strings.TrimSpace(nameFromTags),
+						Input: parsed,
+					}, true
+				}
+			}
+		}
+	}
+
 	dec := xml.NewDecoder(strings.NewReader(block))
 	name := ""
 	params := map[string]any{}
@@ -113,6 +135,12 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 						if parsed := parseToolCallInput(inner); len(parsed) > 0 {
 							if len(parsed) == 1 {
 								if _, onlyRaw := parsed["_raw"]; onlyRaw {
+									if kv := parseXMLChildKV(inner); len(kv) > 0 {
+										for k, vv := range kv {
+											params[k] = vv
+										}
+										break
+									}
 									if kv := parseMarkupKVObject(inner); len(kv) > 0 {
 										for k, vv := range kv {
 											params[k] = vv

--- a/internal/util/toolcalls_test.go
+++ b/internal/util/toolcalls_test.go
@@ -176,6 +176,21 @@ func TestParseToolCallsSupportsCanonicalXMLParametersJSON(t *testing.T) {
 	}
 }
 
+func TestParseToolCallsSupportsXMLParametersJSONWithRawAmpersand(t *testing.T) {
+	text := `<tool_calls><tool_call><tool_name>execute_command</tool_name><parameters>{"command":"sshpass -p 'xxx' ssh -o StrictHostKeyChecking=no -p 1111 root@111.111.111.111 'cd /root && git clone https://github.com/ericc-ch/copilot-api.git'","cwd":null,"timeout":null}</parameters></tool_call></tool_calls>`
+	calls := ParseToolCalls(text, []string{"execute_command"})
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %#v", calls)
+	}
+	if calls[0].Name != "execute_command" {
+		t.Fatalf("expected tool name execute_command, got %q", calls[0].Name)
+	}
+	cmd, _ := calls[0].Input["command"].(string)
+	if !strings.Contains(cmd, "&& git clone https://github.com/ericc-ch/copilot-api.git") {
+		t.Fatalf("expected command preserved, got %#v", calls[0].Input["command"])
+	}
+}
+
 func TestParseToolCallsPrefersJSONPayloadOverIncidentalXMLInString(t *testing.T) {
 	text := `{"tool_calls":[{"name":"search","input":{"q":"latest <tool_call><tool_name>wrong</tool_name><parameters>{\"x\":1}</parameters></tool_call>"}}]}`
 	calls := ParseToolCallsDetailed(text, []string{"search"}).Calls


### PR DESCRIPTION
### Motivation

- Prevent dropping legitimate line breaks when upstream models append leaked `CONTENT_FILTER` markers after a newline. 
- Improve resilience of XML-style tool call parsing to non-XML-safe content (for example raw `&` in shell commands) and better extract tool names and parameters from varied tag names.

### Description

- Update `filterLeakedContentFilterParts`/`stripLeakedContentFilterSuffix` behavior to preserve trailing newline characters and factor the drop logic into `shouldDropCleanedLeakedChunk` which keeps newline-only chunks. 
- Add `shouldDropCleanedLeakedChunk` to avoid dropping chunks that contain `\n` while still removing empty/whitespace-only chunks. 
- Add regex-based extraction for tool name tags via `xmlToolCallNameTagNames` and `xmlToolCallNamePatternByTag` and attempt tag-based parameter parsing before full XML decoding to handle non-XML-safe payloads. 
- Enhance parameter parsing in `parseSingleXMLToolCall` to try `parseXMLChildKV` when `parseToolCallInput` yields only `_raw`, and to merge parsed key/value pairs into `params` when present. 
- Add unit tests in `internal/sse/line_test.go` and `internal/util/toolcalls_test.go` covering preserved newlines before leaked `CONTENT_FILTER` and XML parameter JSON containing raw ampersands.

### Testing

- Ran `go test ./...` including SSE and util packages and all tests completed successfully. 
- New tests `TestParseDeepSeekContentLinePreservesTrailingNewlineBeforeLeakedContentFilter` and `TestParseDeepSeekContentLineKeepsNewlineOnlyChunkBeforeLeakedContentFilter` passed. 
- New test `TestParseToolCallsSupportsXMLParametersJSONWithRawAmpersand` passed and verifies preservation of raw shell commands in parameters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cff809a2248333add6923568d640f1)