### PR TITLE
fix: resolve PR #221/#222 review issues around lint and SSE replay

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,9 +4,13 @@ run:
   tests: true
 
 linters:
-  default: none
+  default: standard
   enable:
     - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - gosimple
     - ineffassign
   settings:
     dupl:

--- a/internal/sse/raw_stream_token_replay_test.go
+++ b/internal/sse/raw_stream_token_replay_test.go
@@ -32,7 +32,10 @@ func TestRawStreamSamplesTokenReplay(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read sample: %v", err)
 			}
-			parsedTokens, expectedTokens := replayAndCollectTokens(string(raw))
+			parsedTokens, expectedTokens, err := replayAndCollectTokens(string(raw))
+			if err != nil {
+				t.Fatalf("scan raw stream: %v", err)
+			}
 			if expectedTokens <= 0 {
 				t.Fatalf("expected positive token usage from raw stream, got %d", expectedTokens)
 			}
@@ -47,9 +50,10 @@ func TestRawStreamSamplesTokenReplay(t *testing.T) {
 	}
 }
 
-func replayAndCollectTokens(raw string) (parsedTokens int, expectedTokens int) {
+func replayAndCollectTokens(raw string) (parsedTokens int, expectedTokens int, scanErr error) {
 	currentType := "thinking"
 	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if !strings.HasPrefix(line, "data:") {
@@ -72,7 +76,10 @@ func replayAndCollectTokens(raw string) (parsedTokens int, expectedTokens int) {
 			parsedTokens = res.OutputTokens
 		}
 	}
-	return parsedTokens, expectedTokens
+	if err := scanner.Err(); err != nil {
+		return 0, 0, err
+	}
+	return parsedTokens, expectedTokens, nil
 }
 
 func rawAccumulatedTokenUsage(v any) int {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,11 +7,49 @@ cd "$ROOT_DIR"
 LINT_BIN="${GOLANGCI_LINT_BIN:-golangci-lint}"
 BOOTSTRAP_VERSION="${GOLANGCI_LINT_VERSION:-v2.11.4}"
 BOOTSTRAP_BIN="${ROOT_DIR}/.tmp/golangci-lint-${BOOTSTRAP_VERSION}"
+BOOTSTRAP_TARGET=""
+
+detect_bootstrap_target() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "$os" in
+    linux|darwin|windows) ;;
+    mingw*|msys*|cygwin*) os="windows" ;;
+    *)
+      echo "unsupported OS for auto-bootstrap: ${os}" >&2
+      return 1
+      ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64) arch="amd64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      echo "unsupported architecture for auto-bootstrap: ${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  BOOTSTRAP_TARGET="${os}-${arch}"
+}
+
+should_bootstrap() {
+  local output="$1"
+  [[ "$output" == *"unknown command \"fmt\" for \"golangci-lint\""* ]] ||
+    [[ "$output" == *"unknown command \"run\" for \"golangci-lint\""* ]] ||
+    [[ "$output" == *"is no longer supported"* ]] ||
+    [[ "$output" == *"unknown flag:"* ]] ||
+    [[ "$output" == *"command not found"* ]] ||
+    [[ "$output" == *"No such file or directory"* ]]
+}
 
 bootstrap_golangci_lint() {
   local version_no_v archive_url tmp_dir
   version_no_v="${BOOTSTRAP_VERSION#v}"
-  archive_url="https://github.com/golangci/golangci-lint/releases/download/${BOOTSTRAP_VERSION}/golangci-lint-${version_no_v}-linux-amd64.tar.gz"
+  detect_bootstrap_target
+  archive_url="https://github.com/golangci/golangci-lint/releases/download/${BOOTSTRAP_VERSION}/golangci-lint-${version_no_v}-${BOOTSTRAP_TARGET}.tar.gz"
 
   mkdir -p "${ROOT_DIR}/.tmp"
   tmp_dir="$(mktemp -d)"
@@ -19,7 +57,7 @@ bootstrap_golangci_lint() {
 
   curl -sSfL "${archive_url}" -o "${tmp_dir}/golangci-lint.tar.gz"
   tar -xzf "${tmp_dir}/golangci-lint.tar.gz" -C "${tmp_dir}"
-  cp "${tmp_dir}/golangci-lint-${version_no_v}-linux-amd64/golangci-lint" "${BOOTSTRAP_BIN}"
+  cp "${tmp_dir}/golangci-lint-${version_no_v}-${BOOTSTRAP_TARGET}/golangci-lint" "${BOOTSTRAP_BIN}"
   chmod +x "${BOOTSTRAP_BIN}"
 
   echo "bootstrapped golangci-lint ${BOOTSTRAP_VERSION} to ${BOOTSTRAP_BIN}" >&2
@@ -43,6 +81,11 @@ fi
 if [[ -n "${GOLANGCI_LINT_BIN:-}" ]]; then
   echo "$lint_output" >&2
   echo "lint failed with explicit GOLANGCI_LINT_BIN=${GOLANGCI_LINT_BIN}; skip auto-bootstrap." >&2
+  exit 1
+fi
+
+if ! should_bootstrap "$lint_output"; then
+  echo "$lint_output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Restore the repository's linting baseline because the migrated `.golangci.yml` disabled many previously enforced checks, reducing CI coverage and allowing regressions.
- Make the SSE token-replay test robust against oversized SSE lines and silent truncation by `bufio.Scanner` to avoid false positives/negatives.
- Prevent `scripts/lint.sh` from needlessly bootstrapping `golangci-lint` on ordinary lint failures and make the bootstrap download cross-platform.

### Description
- Re-enable the standard linter baseline in `.golangci.yml` by setting `default: standard` and explicitly adding `errcheck`, `staticcheck`, `unused`, and `gosimple` while keeping `govet` and `ineffassign` enabled.
- Harden `internal/sse/raw_stream_token_replay_test.go` by increasing the `bufio.Scanner` buffer with `scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)`, returning scanner errors from `replayAndCollectTokens`, and failing the test when a scan error occurs.
- Update `scripts/lint.sh` to detect OS/architecture via `uname` (function `detect_bootstrap_target`) and download the matching `golangci-lint` archive instead of hard-coding `linux-amd64`.
- Make bootstrap conditional with `should_bootstrap()` so the script only auto-downloads when the installed `golangci-lint` is missing or incompatible, and otherwise returns the original lint diagnostics.

### Testing
- Ran `go test ./internal/sse` and it passed (`ok ds2api/internal/sse ...`).
- Verified script syntax with `bash -n scripts/lint.sh`, which returned successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33d2b14b88333b3e1f5bafbc2361e)