### PR TITLE
Treat missing golangci-lint as bootstrap-compatible

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -57,6 +57,9 @@ run_lint() {
 
 is_compatibility_error() {
   case "$1" in
+    *"command not found"*|\
+    *"not recognized as an internal or external command"*|\
+    *"No such file or directory"*|\
     *"unknown command \"fmt\""*|\
     *"unknown command \"run\""*|\
     *"unknown flag"*|\


### PR DESCRIPTION
### Motivation
- The lint bootstrap stopped running automatically when `golangci-lint` was not on `PATH` because missing-executable messages were not recognized as compatibility errors, causing fresh developer environments to fail.

### Description
- Expand `is_compatibility_error` in `scripts/lint.sh` to match common missing-command messages: `command not found`, Windows `not recognized as an internal or external command`, and `No such file or directory`.
- Preserve existing behavior that skips auto-bootstrap when `GOLANGCI_LINT_BIN` is explicitly set.
- Change is contained in `scripts/lint.sh` (matching strings added to the compatibility check).

### Testing
- Ran shell syntax check `bash -n scripts/lint.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3465c6c2c832e91930d06e042e272)