### PR TITLE
fix: avoid double-decoding XML entity text in markup tool-call parsing

### DIFF
--- a/internal/toolcall/toolcalls_parse_markup.go
+++ b/internal/toolcall/toolcalls_parse_markup.go
@@ -145,12 +145,12 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 						params[t.Name.Local] = strings.TrimSpace(v)
 						break
 					}
-					name = strings.TrimSpace(html.UnescapeString(v))
+					name = strings.TrimSpace(v)
 				}
 			case "input", "arguments", "argument", "args", "params":
 				var v string
 				if err := dec.DecodeElement(&v, &t); err == nil && strings.TrimSpace(v) != "" {
-					if parsed := parseToolCallInput(strings.TrimSpace(html.UnescapeString(v))); len(parsed) > 0 {
+					if parsed := parseToolCallInput(strings.TrimSpace(v)); len(parsed) > 0 {
 						for k, vv := range parsed {
 							params[k] = vv
 						}


### PR DESCRIPTION
### Motivation
- 修复 `parseSingleXMLToolCall` 在处理 XML 解码后的字符串时对已解码文本再次调用 `html.UnescapeString`，该重复解码会把像 `&amp;gt;` 这样的字面实体错误变为 `>`，从而篡改工具调用的参数负载。

### Description
- 在 `internal/toolcall/toolcalls_parse_markup.go` 中移除对 `name` 字段和 `input`/`arguments` 字段的冗余 `html.UnescapeString` 调用，改为直接使用 `xml.Decoder.DecodeElement` 返回的字符串值以保留原始实体含义。

### Testing
- 按项目规范运行了依赖和检查：`go mod download`、`npm ci --prefix webui`、`./scripts/lint.sh`（通过），并执行了 `./tests/scripts/run-unit-all.sh`，所有单元测试通过（67/67，失败 0）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d49142ce70832cb39686c23c38175b)