### PR TITLE
Strip fenced code blocks before XML tool-call parsing to avoid executing examples

### DIFF
--- a/internal/toolcall/toolcalls_parse.go
+++ b/internal/toolcall/toolcalls_parse.go
@@ -39,6 +39,11 @@ func parseToolCallsDetailedXMLOnly(text string) ToolCallParseResult {
 		return result
 	}
 	result.SawToolCallSyntax = looksLikeToolCallSyntax(trimmed)
+	trimmed = stripFencedCodeBlocks(trimmed)
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return result
+	}
 
 	parsed := parseXMLToolCalls(trimmed)
 	if len(parsed) == 0 {
@@ -82,4 +87,56 @@ func looksLikeToolCallSyntax(text string) bool {
 		strings.Contains(lower, "<ask_followup_question") ||
 		strings.Contains(lower, "<new_task") ||
 		strings.Contains(lower, "<result")
+}
+
+func stripFencedCodeBlocks(text string) string {
+	if text == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(text))
+
+	lines := strings.SplitAfter(text, "\n")
+	inFence := false
+	fenceMarker := ""
+	for _, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if !inFence {
+			if marker, ok := parseFenceOpen(trimmed); ok {
+				inFence = true
+				fenceMarker = marker
+				continue
+			}
+			b.WriteString(line)
+			continue
+		}
+
+		if isFenceClose(trimmed, fenceMarker) {
+			inFence = false
+			fenceMarker = ""
+		}
+	}
+
+	if inFence {
+		return ""
+	}
+	return b.String()
+}
+
+func parseFenceOpen(line string) (string, bool) {
+	if strings.HasPrefix(line, "```") {
+		return "```", true
+	}
+	if strings.HasPrefix(line, "~~~") {
+		return "~~~", true
+	}
+	return "", false
+}
+
+func isFenceClose(line, marker string) bool {
+	if marker == "" || !strings.HasPrefix(line, marker) {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, marker))
+	return rest == ""
 }

--- a/internal/toolcall/toolcalls_parse.go
+++ b/internal/toolcall/toolcalls_parse.go
@@ -124,19 +124,40 @@ func stripFencedCodeBlocks(text string) string {
 }
 
 func parseFenceOpen(line string) (string, bool) {
-	if strings.HasPrefix(line, "```") {
-		return "```", true
+	if len(line) < 3 {
+		return "", false
 	}
-	if strings.HasPrefix(line, "~~~") {
-		return "~~~", true
+	ch := line[0]
+	if ch != '`' && ch != '~' {
+		return "", false
 	}
-	return "", false
+	count := countLeadingFenceChars(line, ch)
+	if count < 3 {
+		return "", false
+	}
+	return strings.Repeat(string(ch), count), true
 }
 
 func isFenceClose(line, marker string) bool {
-	if marker == "" || !strings.HasPrefix(line, marker) {
+	if marker == "" {
 		return false
 	}
-	rest := strings.TrimSpace(strings.TrimPrefix(line, marker))
+	ch := marker[0]
+	if line == "" || line[0] != ch {
+		return false
+	}
+	count := countLeadingFenceChars(line, ch)
+	if count < len(marker) {
+		return false
+	}
+	rest := strings.TrimSpace(line[count:])
 	return rest == ""
+}
+
+func countLeadingFenceChars(line string, ch byte) int {
+	count := 0
+	for count < len(line) && line[count] == ch {
+		count++
+	}
+	return count
 }

--- a/internal/toolcall/toolcalls_test.go
+++ b/internal/toolcall/toolcalls_test.go
@@ -455,3 +455,22 @@ func TestParseToolCallsUnescapesHTMLEntityArguments(t *testing.T) {
 		t.Fatalf("expected html entities to be unescaped in command, got %q", cmd)
 	}
 }
+
+func TestParseToolCallsIgnoresXMLInsideFencedCodeBlock(t *testing.T) {
+	text := "Here is an example:\n```xml\n<tool_call><tool_name>read_file</tool_name><parameters>{\"path\":\"README.md\"}</parameters></tool_call>\n```\nDo not execute it."
+	res := ParseToolCallsDetailed(text, []string{"read_file"})
+	if len(res.Calls) != 0 {
+		t.Fatalf("expected no parsed calls for fenced example, got %#v", res.Calls)
+	}
+}
+
+func TestParseToolCallsParsesOnlyNonFencedXMLToolCall(t *testing.T) {
+	text := "```xml\n<tool_call><tool_name>read_file</tool_name><parameters>{\"path\":\"README.md\"}</parameters></tool_call>\n```\n<tool_call><tool_name>search</tool_name><parameters>{\"q\":\"golang\"}</parameters></tool_call>"
+	res := ParseToolCallsDetailed(text, []string{"read_file", "search"})
+	if len(res.Calls) != 1 {
+		t.Fatalf("expected exactly one parsed call outside fence, got %#v", res.Calls)
+	}
+	if res.Calls[0].Name != "search" {
+		t.Fatalf("expected non-fenced tool call to be parsed, got %#v", res.Calls[0])
+	}
+}

--- a/internal/toolcall/toolcalls_test.go
+++ b/internal/toolcall/toolcalls_test.go
@@ -474,3 +474,14 @@ func TestParseToolCallsParsesOnlyNonFencedXMLToolCall(t *testing.T) {
 		t.Fatalf("expected non-fenced tool call to be parsed, got %#v", res.Calls[0])
 	}
 }
+
+func TestParseToolCallsParsesAfterFourBacktickFence(t *testing.T) {
+	text := "````markdown\n```xml\n<tool_call><tool_name>read_file</tool_name><parameters>{\"path\":\"README.md\"}</parameters></tool_call>\n```\n````\n<tool_call><tool_name>search</tool_name><parameters>{\"q\":\"outside\"}</parameters></tool_call>"
+	res := ParseToolCallsDetailed(text, []string{"read_file", "search"})
+	if len(res.Calls) != 1 {
+		t.Fatalf("expected exactly one parsed call outside four-backtick fence, got %#v", res.Calls)
+	}
+	if res.Calls[0].Name != "search" {
+		t.Fatalf("expected non-fenced tool call to be parsed, got %#v", res.Calls[0])
+	}
+}


### PR DESCRIPTION
### Motivation
- The XML-only tool-call parser treated `<tool_call>` fragments inside markdown fenced code blocks as real tool calls, which could cause example snippets to be misinterpreted and leak into execution paths.
- The change prevents fenced examples from being promoted to `tool_calls` while preserving detection of real XML tool-call payloads outside fences.

### Description
- Call `stripFencedCodeBlocks` at the start of `parseToolCallsDetailedXMLOnly` to remove fenced markdown blocks before running `parseXMLToolCalls`/`parseMarkupToolCalls` in `internal/toolcall/toolcalls_parse.go`.
- Implement `stripFencedCodeBlocks`, `parseFenceOpen`, and `isFenceClose` helpers to support both triple-backtick (```) and tilde (~~~) fences and to return an empty string when an open fence is left unclosed.
- Add regression tests `TestParseToolCallsIgnoresXMLInsideFencedCodeBlock` and `TestParseToolCallsParsesOnlyNonFencedXMLToolCall` in `internal/toolcall/toolcalls_test.go` to ensure fenced XML is ignored and non-fenced XML is still parsed.
- Applied `gofmt` to the touched files.

### Testing
- Ran `go test ./internal/toolcall -run 'TestParseToolCalls(IgnoresXMLInsideFencedCodeBlock|ParsesOnlyNonFencedXMLToolCall)'` and the tests passed (`ok`).
- Ran the project gates: `./scripts/lint.sh` (no issues), `./tests/scripts/check-refactor-line-gate.sh` (checked), and `./tests/scripts/run-unit-all.sh` (all packages OK).
- Built the web UI with `npm run build --prefix webui` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d16bd810832d91512c16379af0be)