### PR TITLE
修复搜索场景下 citation 标签偶发未替换问题（FINISHED 后继续收集引用元数据）

### DIFF
--- a/internal/sse/consumer.go
+++ b/internal/sse/consumer.go
@@ -29,6 +29,7 @@ func CollectStream(resp *http.Response, thinkingEnabled bool, closeBody bool) Co
 	text := strings.Builder{}
 	thinking := strings.Builder{}
 	contentFilter := false
+	stopped := false
 	collector := newCitationLinkCollector()
 	currentType := "text"
 	if thinkingEnabled {
@@ -37,6 +38,9 @@ func CollectStream(resp *http.Response, thinkingEnabled bool, closeBody bool) Co
 	_ = deepseek.ScanSSELines(resp, func(line []byte) bool {
 		if chunk, done, parsed := ParseDeepSeekSSELine(line); parsed && !done {
 			collector.ingestChunk(chunk)
+		}
+		if stopped {
+			return true
 		}
 		result := ParseDeepSeekContentLine(line, thinkingEnabled, currentType)
 		currentType = result.NextType
@@ -47,7 +51,10 @@ func CollectStream(resp *http.Response, thinkingEnabled bool, closeBody bool) Co
 			if result.ContentFilter {
 				contentFilter = true
 			}
-			return false
+			// Keep scanning to collect late-arriving citation metadata lines
+			// that can appear after response/status=FINISHED.
+			stopped = true
+			return true
 		}
 		for _, p := range result.Parts {
 			if p.Type == "thinking" {

--- a/internal/sse/consumer_edge_test.go
+++ b/internal/sse/consumer_edge_test.go
@@ -185,6 +185,24 @@ func TestCollectStreamExtractsCitationLinksWithRepeatedURLsAndNilIndices(t *test
 	}
 }
 
+func TestCollectStreamCollectsCitationLinksAfterFinished(t *testing.T) {
+	resp := makeHTTPResponse(
+		"data: {\"p\":\"response/content\",\"v\":\"结论[citation:1]\"}\n" +
+			"data: {\"p\":\"response/status\",\"v\":\"FINISHED\"}\n" +
+			"data: {\"p\":\"response/fragments/-1/results\",\"v\":[{\"url\":\"https://example.com/a\",\"cite_index\":1}]}\n" +
+			"data: {\"p\":\"response/content\",\"v\":\"should-not-append\"}\n" +
+			"data: [DONE]\n",
+	)
+
+	result := CollectStream(resp, false, false)
+	if result.Text != "结论[citation:1]" {
+		t.Fatalf("expected text to freeze after finished, got %q", result.Text)
+	}
+	if got := result.CitationLinks[1]; got != "https://example.com/a" {
+		t.Fatalf("expected citation 1 link, got %q", got)
+	}
+}
+
 func TestCollectStreamMultipleThinkingChunks(t *testing.T) {
 	resp := makeHTTPResponse(
 		"data: {\"p\":\"response/thinking_content\",\"v\":\"part1\"}\n" +


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [✅ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

问题描述

使用 deepseek-chat-search 等搜索模型时，非流式响应（stream: false）偶发出现 [citation:1]、[citation:2] 等原始标签未被替换为 Markdown 链接的问题。

根因分析

DeepSeek 上游 SSE 流的结构中，response/status=FINISHED 信号并不是流的最后一行。引用元数据（cite_index / url，位于 response/fragments/-1/results 路径下）通常在 FINISHED 信号之后才到达。

修复前，consumer.go 中的 CollectStream 函数在遇到 Stop 信号时立即 return false，终止了 bufio.Scanner 的扫描循环，导致后续的引用元数据行根本没有被 ingestChunk 处理，CitationLinks 映射表因此不完整，替换阶段找不到对应 URL，只能保留原始标签。

修复方案

在 consumer.go 中引入 stopped 布尔标志：

遇到 Stop 信号时，将 stopped 置为 true，但继续让 Scanner 扫描后续行（返回 true 而非 false）
每次循环在 ingestChunk 之后、文本累积之前检查 stopped：若已停止则跳过文本/思考内容的追加，直接进入下一行
这样 Stop 之后到达的所有行依然会被 ingestChunk 处理并填充 CitationLinks，而正文内容不会被污染
同步添加回归测试

在 consumer_edge_test.go 中新增测试用例 TestCollectStreamCollectsCitationLinksAfterFinished，验证：

FINISHED 信号之后的文本行不会追加进入正文
FINISHED 信号之后的引用元数据行能被正确收集
最终 CollectResult.CitationLinks 包含完整的引用链接映射
影响范围

仅影响 CollectStream 非流式收集路径
不改变流式（stream: true）响应的处理逻辑
不影响无引用的普通对话场景