### PR TITLE
Fix webui batch import template Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:24 AS webui-builder
 WORKDIR /app/webui
 COPY webui/package.json webui/package-lock.json ./
 RUN npm ci
+COPY config.example.json /app/config.example.json
 COPY webui ./
 RUN npm run build
 


### PR DESCRIPTION
## 变更说明
- 在 `webui-builder` 阶段显式复制仓库根目录的 `config.example.json`
- 保持 `webui/src/utils/batchImportTemplates.js` 继续从仓库根目录导入配置模板
- 修复 Docker / Zeabur 构建环境中缺少 `config.example.json` 导致的前端构建失败

## 原因
`batchImportTemplates.js` 依赖仓库根目录的 `config.example.json`。本地直接执行 `npm run build --prefix webui` 时可以访问该文件，但 Docker 构建的 `webui-builder` 阶段原先只复制了 `webui/` 目录内容，导致构建容器内不存在 `/app/config.example.json`，从而报出 `UNRESOLVED_IMPORT`。

本次修复采用单一来源方案：不复制前端模板文件，只在 Docker 构建阶段补齐所需输入文件。

## 测试计划
已在本地开发容器中完成以下验证：
- [x] `./scripts/lint.sh`
- [x] `./tests/scripts/check-refactor-line-gate.sh`
- [x] `./tests/scripts/run-unit-all.sh`
- [x] `npm run build --prefix webui`
- [x] `docker build -t ds2api-zeabur-check .`

其中最后一项用于模拟 Zeabur 云平台的 Docker 构建流程，已确认通过。