### PR TITLE
fix: strip content-encoding header in proxyToGo to prevent Brotli decode error

### DIFF
--- a/internal/js/chat-stream/proxy_go.js
+++ b/internal/js/chat-stream/proxy_go.js
@@ -53,7 +53,8 @@ async function proxyToGo(req, res, rawBody) {
 
     res.statusCode = upstream.status;
     upstream.headers.forEach((value, key) => {
-      if (key.toLowerCase() === 'content-length') {
+      const lower = key.toLowerCase();
+      if (lower === 'content-length' || lower === 'content-encoding') {
         return;
       }
       res.setHeader(key, value);


### PR DESCRIPTION
## Bug Description

When `proxyToGo` forwards the upstream Go handler's response to the client, Node.js `fetch()` auto-decompresses the response body (Brotli/gzip/deflate). However, the original `content-encoding` header is still forwarded as-is, causing a mismatch: the body is already decompressed but the header still says it's compressed.

Clients (Python `requests`, etc.) then attempt to decompress already-decompressed data, resulting in:
```
('Received response with content-encoding: br, but failed to decode it.', 
 error('BrotliDecoderDecompressStream failed while processing the stream'))
```

This only manifests on **non-streaming** responses with larger bodies that trigger Vercel's CDN compression.

## Root Cause

`proxy_go.js` already strips `content-length` (because the decompressed body has a different length), but forgot to also strip `content-encoding`. The existing code:

```js
upstream.headers.forEach((value, key) => {
  if (key.toLowerCase() === 'content-length') {
    return;
  }
  res.setHeader(key, value);
});
```

## Fix

Also strip `content-encoding` so that downstream proxies (Vercel CDN) can re-compress with correct headers:

```js
upstream.headers.forEach((value, key) => {
  const lower = key.toLowerCase();
  if (lower === 'content-length' || lower === 'content-encoding') {
    return;
  }
  res.setHeader(key, value);
});
```

## Testing

Verified on our Vercel deployment:
- Before fix: non-streaming long responses (>1KB) → Brotli decode error
- After fix: non-streaming long responses (tested 10KB+) → works correctly
- Streaming responses: unaffected (already worked via SSE line-by-line reading)
