### PR TITLE
fix(webui): 替换uuid依赖，解决http环境下无法生成密钥的问题。

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -13,7 +13,8 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-router-dom": "^7.13.0",
-                "tailwind-merge": "^3.4.0"
+                "tailwind-merge": "^3.4.0",
+                "uuid": "^14.0.0"
             },
             "devDependencies": {
                 "@vitejs/plugin-react": "^6.0.1",
@@ -2020,6 +2021,19 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist-node/bin/uuid"
+            }
         },
         "node_modules/vite": {
             "version": "8.0.5",

--- a/webui/package.json
+++ b/webui/package.json
@@ -14,7 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.13.0",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "uuid": "^14.0.0"
     },
     "devDependencies": {
         "@vitejs/plugin-react": "^6.0.1",

--- a/webui/src/features/account/AddKeyModal.jsx
+++ b/webui/src/features/account/AddKeyModal.jsx
@@ -1,4 +1,5 @@
 import { X } from 'lucide-react'
+import { v4 as uuidv4 } from 'uuid'
 
 export default function AddKeyModal({ show, t, editingKey, newKey, setNewKey, loading, onClose, onAdd }) {
     if (!show) {
@@ -32,7 +33,7 @@ export default function AddKeyModal({ show, t, editingKey, newKey, setNewKey, lo
                             {!isEditing && (
                                 <button
                                     type="button"
-                                    onClick={() => setNewKey({ ...newKey, key: 'sk-' + crypto.randomUUID().replace(/-/g, '') })}
+                                    onClick={() => setNewKey({ ...newKey, key: 'sk-' + uuidv4().replace(/-/g, '') })}
                                     className="px-3 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors text-sm font-medium border border-border whitespace-nowrap"
                                 >
                                     {t('accountManager.generate')}


### PR DESCRIPTION
原生的`crypto.randomUUID()`只支持https和localhost的安全上下文环境。

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
修复了webui在http环境下无法生成密钥的问题

`webui/src/features/account/AddKeyModal.jsx`文件第35行
```js
 onClick={() => setNewKey({ ...newKey, key: 'sk-' + crypto.randomUUID().replace(/-/g, '') })}
```
使用了`crypto.randomUUID()`，此方法只能在安全上下文环境使用，https和http的localhost属于安全上下文，其他http环境属于不安全，浏览器会控制台报错：`Uncaught TypeError: crypto.randomUUID is not a function at onClick`。

uuid方法 换成了npm的uuid库，就可以在不安全上下文环境里使用了