### PR TITLE
修复 XML 工具调用流式解析、包装恢复与泄漏清理（优化openclaw接入ds2api后的工具调用能力）

### DIFF
--- a/internal/adapter/openai/chat_stream_runtime.go
+++ b/internal/adapter/openai/chat_stream_runtime.go
@@ -32,11 +32,12 @@ type chatStreamRuntime struct {
 	toolCallsEmitted     bool
 	toolCallsDoneEmitted bool
 
-	toolSieve         toolStreamSieveState
-	streamToolCallIDs map[int]string
-	streamToolNames   map[int]string
-	thinking          strings.Builder
-	text              strings.Builder
+	toolSieve           toolStreamSieveState
+	emittedToolCallKeys map[string]struct{}
+	streamToolCallIDs   map[int]string
+	streamToolNames     map[int]string
+	thinking            strings.Builder
+	text                strings.Builder
 
 	finalThinking     string
 	finalText         string
@@ -76,6 +77,7 @@ func newChatStreamRuntime(
 		stripReferenceMarkers: stripReferenceMarkers,
 		bufferToolContent:     bufferToolContent,
 		emitEarlyToolDeltas:   emitEarlyToolDeltas,
+		emittedToolCallKeys:   map[string]struct{}{},
 		streamToolCallIDs:     map[int]string{},
 		streamToolNames:       map[int]string{},
 	}
@@ -129,11 +131,12 @@ func (s *chatStreamRuntime) resetStreamToolCallState() {
 
 func (s *chatStreamRuntime) finalize(finishReason string) {
 	finalThinking := s.thinking.String()
-	finalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
+	finalText := stripVisibleToolCallMarkup(cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers))
 	s.finalThinking = finalThinking
 	s.finalText = finalText
 	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
-	if len(detected.Calls) > 0 && !s.toolCallsDoneEmitted {
+	detected.Calls = filterNewParsedToolCalls(detected.Calls, s.emittedToolCallKeys)
+	if len(detected.Calls) > 0 {
 		finishReason = "tool_calls"
 		delta := map[string]any{
 			"tool_calls": formatFinalStreamToolCallsWithStableIDs(detected.Calls, s.streamToolCallIDs),
@@ -154,11 +157,15 @@ func (s *chatStreamRuntime) finalize(finishReason string) {
 	} else if s.bufferToolContent {
 		for _, evt := range flushToolSieve(&s.toolSieve, s.toolNames) {
 			if len(evt.ToolCalls) > 0 {
+				filteredCalls := filterNewParsedToolCalls(evt.ToolCalls, s.emittedToolCallKeys)
+				if len(filteredCalls) == 0 {
+					continue
+				}
 				finishReason = "tool_calls"
 				s.toolCallsEmitted = true
 				s.toolCallsDoneEmitted = true
 				tcDelta := map[string]any{
-					"tool_calls": formatFinalStreamToolCallsWithStableIDs(evt.ToolCalls, s.streamToolCallIDs),
+					"tool_calls": formatFinalStreamToolCallsWithStableIDs(filteredCalls, s.streamToolCallIDs),
 				}
 				if !s.firstChunkSent {
 					tcDelta["role"] = "assistant"
@@ -176,7 +183,7 @@ func (s *chatStreamRuntime) finalize(finishReason string) {
 			if evt.Content == "" {
 				continue
 			}
-			cleaned := cleanVisibleOutput(evt.Content, s.stripReferenceMarkers)
+			cleaned := stripVisibleToolCallMarkup(cleanVisibleOutput(evt.Content, s.stripReferenceMarkers))
 			if cleaned == "" {
 				continue
 			}
@@ -248,7 +255,7 @@ func (s *chatStreamRuntime) onParsed(parsed sse.LineResult) streamengine.ParsedD
 	newChoices := make([]map[string]any, 0, len(parsed.Parts))
 	contentSeen := false
 	for _, p := range parsed.Parts {
-		cleanedText := cleanVisibleOutput(p.Text, s.stripReferenceMarkers)
+		cleanedText := stripVisibleToolCallMarkup(cleanVisibleOutput(p.Text, s.stripReferenceMarkers))
 		if s.searchEnabled && sse.IsCitation(cleanedText) {
 			continue
 		}
@@ -305,10 +312,14 @@ func (s *chatStreamRuntime) onParsed(parsed sse.LineResult) streamengine.ParsedD
 						continue
 					}
 					if len(evt.ToolCalls) > 0 {
+						filteredCalls := filterNewParsedToolCalls(evt.ToolCalls, s.emittedToolCallKeys)
+						if len(filteredCalls) == 0 {
+							continue
+						}
 						s.toolCallsEmitted = true
 						s.toolCallsDoneEmitted = true
 						tcDelta := map[string]any{
-							"tool_calls": formatFinalStreamToolCallsWithStableIDs(evt.ToolCalls, s.streamToolCallIDs),
+							"tool_calls": formatFinalStreamToolCallsWithStableIDs(filteredCalls, s.streamToolCallIDs),
 						}
 						if !s.firstChunkSent {
 							tcDelta["role"] = "assistant"

--- a/internal/adapter/openai/leaked_output_sanitize.go
+++ b/internal/adapter/openai/leaked_output_sanitize.go
@@ -35,6 +35,8 @@ var leakedAgentWrapperTagPattern = regexp.MustCompile(`(?is)</?(?:attempt_comple
 var leakedAgentWrapperPlusResultOpenPattern = regexp.MustCompile(`(?is)<(?:attempt_completion|ask_followup_question|new_task)\b[^>]*>\s*<result>`)
 var leakedAgentResultPlusWrapperClosePattern = regexp.MustCompile(`(?is)</result>\s*</(?:attempt_completion|ask_followup_question|new_task)\b[^>]*>`)
 var leakedAgentResultTagPattern = regexp.MustCompile(`(?is)</?result>`)
+var leakedToolCallsWrapperFragmentPattern = regexp.MustCompile(`(?im)^\s*(?:</?tool_calls>|tool_calls>)\s*$`)
+var leakedToolCallClosingFragmentPattern = regexp.MustCompile(`(?im)^\s*(?:</tool_call>|</parameter>|</parameters>|</tool_name>|</function_name>)\s*$`)
 
 func sanitizeLeakedOutput(text string) string {
 	if text == "" {
@@ -48,6 +50,8 @@ func sanitizeLeakedOutput(text string) string {
 	out = leakedBOSMarkerPattern.ReplaceAllString(out, "")
 	out = leakedMetaMarkerPattern.ReplaceAllString(out, "")
 	out = sanitizeLeakedAgentXMLBlocks(out)
+	out = leakedToolCallsWrapperFragmentPattern.ReplaceAllString(out, "")
+	out = leakedToolCallClosingFragmentPattern.ReplaceAllString(out, "")
 	return out
 }
 

--- a/internal/adapter/openai/responses_stream_runtime_core.go
+++ b/internal/adapter/openai/responses_stream_runtime_core.go
@@ -33,6 +33,7 @@ type responsesStreamRuntime struct {
 	toolCallsEmitted     bool
 	toolCallsDoneEmitted bool
 
+	emittedToolCallKeys map[string]struct{}
 	sieve             toolStreamSieveState
 	thinking          strings.Builder
 	text              strings.Builder
@@ -85,6 +86,7 @@ func newResponsesStreamRuntime(
 		toolNames:             toolNames,
 		bufferToolContent:     bufferToolContent,
 		emitEarlyToolDeltas:   emitEarlyToolDeltas,
+		emittedToolCallKeys: map[string]struct{}{},
 		streamToolCallIDs:     map[int]string{},
 		functionItemIDs:       map[int]string{},
 		functionOutputIDs:     map[int]int{},
@@ -125,14 +127,15 @@ func (s *responsesStreamRuntime) failResponse(message, code string) {
 
 func (s *responsesStreamRuntime) finalize() {
 	finalThinking := s.thinking.String()
-	finalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
+	rawFinalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
 
 	if s.bufferToolContent {
 		s.processToolStreamEvents(flushToolSieve(&s.sieve, s.toolNames), true, true)
+		finalText := stripVisibleToolCallMarkup(cleanVisibleOutput(s.visibleText.String(), s.stripReferenceMarkers))
 	}
 
-	textParsed := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
-	detected := textParsed.Calls
+	textParsed := toolcall.ParseStandaloneToolCallsDetailed(rawFinalText, s.toolNames)
+	detected := filterNewParsedToolCalls(textParsed.Calls, s.emittedToolCallKeys)
 	s.logToolPolicyRejections(textParsed)
 
 	if len(detected) > 0 {
@@ -221,8 +224,11 @@ func (s *responsesStreamRuntime) onParsed(parsed sse.LineResult) streamengine.Pa
 		}
 		s.text.WriteString(trimmed)
 		if !s.bufferToolContent {
-			s.emitTextDelta(trimmed)
-			continue
+		 visible := stripVisibleToolCallMarkup(trimmed)
+		 if visible != "" {
+		 s.emitTextDelta(visible)
+		 }
+		 continue
 		}
 		s.processToolStreamEvents(processToolSieveChunk(&s.sieve, trimmed, s.toolNames), true, true)
 	}

--- a/internal/adapter/openai/responses_stream_runtime_events.go
+++ b/internal/adapter/openai/responses_stream_runtime_events.go
@@ -41,7 +41,7 @@ func (s *responsesStreamRuntime) sendDone() {
 
 func (s *responsesStreamRuntime) processToolStreamEvents(events []toolStreamEvent, emitContent bool, resetAfterToolCalls bool) {
 	for _, evt := range events {
-		if emitContent && evt.Content != "" {
+		if emitContent && evt.Content != "" { cleaned := stripVisibleToolCallMarkup(cleanVisibleOutput(evt.Content, s.stripReferenceMarkers)); if cleaned != "" { s.emitTextDelta(cleaned) } }
 			s.emitTextDelta(evt.Content)
 		}
 		if len(evt.ToolCallDeltas) > 0 {
@@ -54,7 +54,7 @@ func (s *responsesStreamRuntime) processToolStreamEvents(events []toolStreamEven
 			}
 			s.emitFunctionCallDeltaEvents(filtered)
 		}
-		if len(evt.ToolCalls) > 0 {
+		if len(evt.ToolCalls) > 0 { filteredCalls := filterNewParsedToolCalls(evt.ToolCalls, s.emittedToolCallKeys); if len(filteredCalls) == 0 { continue } s.emitFunctionCallDoneEvents(filteredCalls); if resetAfterToolCalls { s.resetStreamToolCallState() } }
 			s.emitFunctionCallDoneEvents(evt.ToolCalls)
 			if resetAfterToolCalls {
 				s.resetStreamToolCallState()

--- a/internal/adapter/openai/tool_sieve_core.go
+++ b/internal/adapter/openai/tool_sieve_core.go
@@ -26,7 +26,7 @@ func processToolSieveChunk(state *toolStreamSieveState, chunk string, toolNames 
 				state.capture.WriteString(state.pending.String())
 				state.pending.Reset()
 			}
-			prefix, calls, suffix, ready := consumeToolCapture(state, toolNames)
+			prefix, calls, suffix, ready := consumeToolCapture(state, toolNames, false)
 			if !ready {
 				break
 			}
@@ -98,7 +98,7 @@ func flushToolSieve(state *toolStreamSieveState, toolNames []string) []toolStrea
 		state.pendingToolCalls = nil
 	}
 	if state.capturing {
-		consumedPrefix, consumedCalls, consumedSuffix, ready := consumeToolCapture(state, toolNames)
+		consumedPrefix, consumedCalls, consumedSuffix, ready := consumeToolCapture(state, toolNames, true)
 		if ready {
 			if consumedPrefix != "" {
 				state.noteText(consumedPrefix)
@@ -113,9 +113,9 @@ func flushToolSieve(state *toolStreamSieveState, toolNames []string) []toolStrea
 			}
 		} else {
 			content := state.capture.String()
-			if content != "" {
-				// If capture never resolved into a real tool call, release the
-				// buffered text instead of swallowing it.
+			if content != "" && !hasOpenXMLToolTag(content) {
+				// Suppress unterminated XML tool markup at flush time instead of
+				// leaking raw executable-looking tags into visible output.
 				state.noteText(content)
 				events = append(events, toolStreamEvent{Content: content})
 			}
@@ -126,9 +126,11 @@ func flushToolSieve(state *toolStreamSieveState, toolNames []string) []toolStrea
 	}
 	if state.pending.Len() > 0 {
 		content := state.pending.String()
-		// If pending never resolved into a real tool call, release it as text.
-		state.noteText(content)
-		events = append(events, toolStreamEvent{Content: content})
+		// Do not leak trailing partial/open XML tool markup on flush.
+		if !hasOpenXMLToolTag(content) && findPartialXMLToolTagStart(content) < 0 {
+			state.noteText(content)
+			events = append(events, toolStreamEvent{Content: content})
+		}
 		state.pending.Reset()
 	}
 	return events
@@ -179,14 +181,14 @@ func findToolSegmentStart(state *toolStreamSieveState, s string) int {
 	}
 }
 
-func consumeToolCapture(state *toolStreamSieveState, toolNames []string) (prefix string, calls []toolcall.ParsedToolCall, suffix string, ready bool) {
+func consumeToolCapture(state *toolStreamSieveState, toolNames []string, finalize bool) (prefix string, calls []toolcall.ParsedToolCall, suffix string, ready bool) {
 	captured := state.capture.String()
 	if captured == "" {
 		return "", nil, "", false
 	}
 
 	// XML tool call extraction only.
-	if xmlPrefix, xmlCalls, xmlSuffix, xmlReady := consumeXMLToolCapture(captured, toolNames); xmlReady {
+	if xmlPrefix, xmlCalls, xmlSuffix, xmlReady := consumeXMLToolCapture(captured, toolNames, finalize); xmlReady {
 		return xmlPrefix, xmlCalls, xmlSuffix, true
 	}
 	// If XML tags are present but block is incomplete, keep buffering.

--- a/internal/adapter/openai/tool_sieve_xml.go
+++ b/internal/adapter/openai/tool_sieve_xml.go
@@ -44,8 +44,37 @@ var xmlToolTagsToDetect = []string{"<tool_calls>", "<tool_calls\n", "<tool_call>
 	// Agent-style tags
 	"<attempt_completion>", "<ask_followup_question>", "<new_task>"}
 
+var xmlToolCallOpenTagPattern = regexp.MustCompile(`(?is)<tool_call\b`)
+
+func countXMLToolCallOpenTags(text string) int {
+	return len(xmlToolCallOpenTagPattern.FindAllStringIndex(text, -1))
+}
+
+func countXMLToolCallCloseTags(text string) int {
+	return strings.Count(strings.ToLower(text), "</tool_call>")
+}
+
+func looksLikeExecutableXMLToolCall(block string) bool {
+	lower := strings.ToLower(block)
+	if !(strings.Contains(lower, "<tool_call") ||
+		strings.Contains(lower, "<tool_calls") ||
+		strings.Contains(lower, "<invoke") ||
+		strings.Contains(lower, "<function_call") ||
+		strings.Contains(lower, "<function_calls") ||
+		strings.Contains(lower, "<tool_use")) {
+		return false
+	}
+	return strings.Contains(lower, "<tool_name") ||
+		strings.Contains(lower, "<function_name") ||
+		strings.Contains(lower, "<parameters") ||
+		strings.Contains(lower, "<parameter") ||
+		strings.Contains(lower, "<arguments") ||
+		strings.Contains(lower, "<argument") ||
+		strings.Contains(lower, " name=")
+}
+
 // consumeXMLToolCapture tries to extract complete XML tool call blocks from captured text.
-func consumeXMLToolCapture(captured string, toolNames []string) (prefix string, calls []toolcall.ParsedToolCall, suffix string, ready bool) {
+func consumeXMLToolCapture(captured string, toolNames []string, finalize bool) (prefix string, calls []toolcall.ParsedToolCall, suffix string, ready bool) {
 	lower := strings.ToLower(captured)
 	// Find the FIRST matching open/close pair, preferring wrapper tags.
 	// Tag pairs are ordered longest-first (e.g. <tool_calls before <tool_call)
@@ -68,10 +97,17 @@ func consumeXMLToolCapture(captured string, toolNames []string) (prefix string, 
 		xmlBlock := captured[openIdx:closeEnd]
 		prefixPart := captured[:openIdx]
 		suffixPart := captured[closeEnd:]
+		if !finalize && pair.open == "<tool_calls" && countXMLToolCallOpenTags(xmlBlock) > countXMLToolCallCloseTags(xmlBlock) {
+			return "", nil, "", false
+		}
 		parsed := toolcall.ParseToolCalls(xmlBlock, toolNames)
 		if len(parsed) > 0 {
 			prefixPart, suffixPart = trimWrappingJSONFence(prefixPart, suffixPart)
 			return prefixPart, parsed, suffixPart, true
+		}
+		if looksLikeExecutableXMLToolCall(xmlBlock) {
+			prefixPart, suffixPart = trimWrappingJSONFence(prefixPart, suffixPart)
+			return prefixPart, nil, suffixPart, true
 		}
 		// If this block failed to become a tool call, pass it through as text.
 		return prefixPart + xmlBlock, nil, suffixPart, true

--- a/internal/adapter/openai/tool_sieve_xml_test.go
+++ b/internal/adapter/openai/tool_sieve_xml_test.go
@@ -164,6 +164,34 @@ func TestProcessToolSieveNonToolXMLKeepsSuffixForToolParsing(t *testing.T) {
 	}
 }
 
+func TestProcessToolSieveRepairsPrematureToolCallsWrapperClosuresOnFlush(t *testing.T) {
+	var state toolStreamSieveState
+	chunks := []string{
+		"<tool_calls>\n<tool_call>\n<tool_name>exec</tool_name>\n<parameters><command><![CDATA[pwd]]></command></parameters>\n</tool_calls>",
+		"<tool_call>\n<tool_name>memory_search</tool_name>\n<parameters><query><![CDATA[test query]]></query></parameters>\n</tool_calls>",
+	}
+	var events []toolStreamEvent
+	for _, c := range chunks {
+		events = append(events, processToolSieveChunk(&state, c, []string{"exec", "memory_search"})...)
+	}
+	events = append(events, flushToolSieve(&state, []string{"exec", "memory_search"})...)
+
+	var textContent strings.Builder
+	var calls []string
+	for _, evt := range events {
+		textContent.WriteString(evt.Content)
+		for _, tc := range evt.ToolCalls {
+			calls = append(calls, tc.Name)
+		}
+	}
+	if textContent.Len() != 0 {
+		t.Fatalf("expected malformed wrapper output to be repaired without text leak, got %q", textContent.String())
+	}
+	if len(calls) != 2 || calls[0] != "exec" || calls[1] != "memory_search" {
+		t.Fatalf("expected repaired tool calls, got %#v events=%#v", calls, events)
+	}
+}
+
 func TestProcessToolSievePassesThroughMalformedExecutableXMLBlock(t *testing.T) {
 	var state toolStreamSieveState
 	chunk := `<tool_call><parameters>{"path":"README.md"}</parameters></tool_call>`

--- a/internal/adapter/openai/toolcall_dedupe.go
+++ b/internal/adapter/openai/toolcall_dedupe.go
@@ -1,0 +1,34 @@
+package openai
+
+import (
+	"ds2api/internal/toolcall"
+	"encoding/json"
+	"strings"
+)
+
+func parsedToolCallKey(tc toolcall.ParsedToolCall) string {
+	name := strings.TrimSpace(tc.Name)
+	if name == "" {
+		return ""
+	}
+	argsBytes, _ := json.Marshal(tc.Input)
+	return name + "::" + string(argsBytes)
+}
+
+func filterNewParsedToolCalls(calls []toolcall.ParsedToolCall, seen map[string]struct{}) []toolcall.ParsedToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]toolcall.ParsedToolCall, 0, len(calls))
+	for _, tc := range calls {
+		key := parsedToolCallKey(tc)
+		if key != "" {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		out = append(out, tc)
+	}
+	return out
+}

--- a/internal/adapter/openai/visible_tool_markup.go
+++ b/internal/adapter/openai/visible_tool_markup.go
@@ -1,0 +1,20 @@
+package openai
+
+import "regexp"
+
+var visibleToolXMLBlockPatterns = []*regexp.Regexp{
+regexp.MustCompile(`(?is)<tool_calls\b[^>]*>[\s\S]*?</tool_calls>`),
+regexp.MustCompile(`(?is)<tool_call\b[^>]*>[\s\S]*?</tool_call>`),
+regexp.MustCompile(`(?is)<tool_calls\b[^>]*>[\s\S]*$`),
+regexp.MustCompile(`(?is)<tool_call\b[^>]*>[\s\S]*$`),
+}
+
+func stripVisibleToolCallMarkup(text string) string {
+out := text
+for _, pattern := range visibleToolXMLBlockPatterns {
+out = pattern.ReplaceAllString(out, "")
+}
+out = leakedToolCallsWrapperFragmentPattern.ReplaceAllString(out, "")
+out = leakedToolCallClosingFragmentPattern.ReplaceAllString(out, "")
+return out
+}

--- a/internal/js/chat-stream/toolcall_policy.js
+++ b/internal/js/chat-stream/toolcall_policy.js
@@ -15,7 +15,7 @@ function resolveToolcallPolicy(prepBody, payloadTools) {
   return {
     toolNames,
     toolSieveEnabled: toolNames.length > 0,
-    emitEarlyToolDeltas: true,
+    emitEarlyToolDeltas: false,
   };
 }
 

--- a/internal/js/chat-stream/vercel_stream_impl.js
+++ b/internal/js/chat-stream/vercel_stream_impl.js
@@ -33,6 +33,53 @@ const {
 } = require('./dedupe');
 
 const DEEPSEEK_COMPLETION_URL = 'https://chat.deepseek.com/api/v0/chat/completion';
+const LEAKED_TOOL_WRAPPER_FRAGMENT_PATTERN = /^\s*(?:<\/tool_calls>|<tool_calls>|tool_calls>)\s*$/i;
+
+function sanitizeVisibleChunkText(text) {
+  const value = typeof text === 'string' ? text : '';
+  if (!value) {
+    return '';
+  }
+  if (LEAKED_TOOL_WRAPPER_FRAGMENT_PATTERN.test(value)) {
+    return '';
+  }
+  return value;
+}
+
+function toolCallKey(call) {
+  if (!call || typeof call !== 'object') {
+    return '';
+  }
+  const name = typeof call.name === 'string' ? call.name.trim() : '';
+  const input = call.input && typeof call.input === 'object' && !Array.isArray(call.input) ? call.input : {};
+  try {
+    return `${name}::${JSON.stringify(input)}`;
+  } catch (_err) {
+    return `${name}::`;
+  }
+}
+
+function filterNewToolCalls(calls, emittedKeys) {
+  if (!Array.isArray(calls) || calls.length === 0) {
+    return [];
+  }
+  const out = [];
+  for (const call of calls) {
+    const key = toolCallKey(call);
+    if (!key) {
+      out.push(call);
+      continue;
+    }
+    if (emittedKeys && emittedKeys.has(key)) {
+      continue;
+    }
+    if (emittedKeys) {
+      emittedKeys.add(key);
+    }
+    out.push(call);
+  }
+  return out;
+}
 
 async function handleVercelStream(req, res, rawBody, payload) {
   const prep = await fetchStreamPrepare(req, rawBody);
@@ -129,6 +176,7 @@ async function handleVercelStream(req, res, rawBody, payload) {
     const toolSieveEnabled = toolPolicy.toolSieveEnabled;
     const toolSieveState = createToolSieveState();
     let toolCallsEmitted = false;
+    const emittedToolCallKeys = new Set();
     const streamToolCallIDs = new Map();
     const streamToolNames = new Map();
     const decoder = new TextDecoder();
@@ -152,21 +200,26 @@ async function handleVercelStream(req, res, rawBody, payload) {
         await releaseLease();
         return;
       }
-      const detected = parseStandaloneToolCalls(outputText, toolNames);
-      if (detected.length > 0 && !toolCallsEmitted) {
+      const detected = filterNewToolCalls(parseStandaloneToolCalls(outputText, toolNames), emittedToolCallKeys);
+      if (detected.length > 0) {
         toolCallsEmitted = true;
         sendDeltaFrame({ tool_calls: formatOpenAIStreamToolCalls(detected, streamToolCallIDs) });
       } else if (toolSieveEnabled) {
         const tailEvents = flushToolSieve(toolSieveState, toolNames);
         for (const evt of tailEvents) {
           if (evt.type === 'tool_calls' && Array.isArray(evt.calls) && evt.calls.length > 0) {
+            const filteredCalls = filterNewToolCalls(evt.calls, emittedToolCallKeys);
+            if (filteredCalls.length === 0) {
+              continue;
+            }
             toolCallsEmitted = true;
-            sendDeltaFrame({ tool_calls: formatOpenAIStreamToolCalls(evt.calls, streamToolCallIDs) });
+            sendDeltaFrame({ tool_calls: formatOpenAIStreamToolCalls(filteredCalls, streamToolCallIDs) });
             resetStreamToolCallState(streamToolCallIDs, streamToolNames);
             continue;
           }
-          if (evt.text) {
-            sendDeltaFrame({ content: evt.text });
+          const cleaned = sanitizeVisibleChunkText(evt.text);
+          if (cleaned) {
+            sendDeltaFrame({ content: cleaned });
           }
         }
       }
@@ -283,13 +336,18 @@ async function handleVercelStream(req, res, rawBody, payload) {
                   continue;
                 }
                 if (evt.type === 'tool_calls') {
+                  const filteredCalls = filterNewToolCalls(evt.calls, emittedToolCallKeys);
+                  if (filteredCalls.length === 0) {
+                    continue;
+                  }
                   toolCallsEmitted = true;
-                  sendDeltaFrame({ tool_calls: formatOpenAIStreamToolCalls(evt.calls, streamToolCallIDs) });
+                  sendDeltaFrame({ tool_calls: formatOpenAIStreamToolCalls(filteredCalls, streamToolCallIDs) });
                   resetStreamToolCallState(streamToolCallIDs, streamToolNames);
                   continue;
                 }
-                if (evt.text) {
-                  sendDeltaFrame({ content: evt.text });
+                const cleaned = sanitizeVisibleChunkText(evt.text);
+                if (cleaned) {
+                  sendDeltaFrame({ content: cleaned });
                 }
               }
             }

--- a/internal/js/helpers/stream-tool-sieve/parse_payload.js
+++ b/internal/js/helpers/stream-tool-sieve/parse_payload.js
@@ -2,8 +2,16 @@
 
 const TOOL_CALL_MARKUP_BLOCK_PATTERN = /<(?:[a-z0-9_:-]+:)?(tool_call|function_call|invoke)\b([^>]*)>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?\1>/gi;
 const TOOL_CALL_MARKUP_SELFCLOSE_PATTERN = /<(?:[a-z0-9_:-]+:)?invoke\b([^>]*)\/>/gi;
-const TOOL_CALL_MARKUP_KV_PATTERN = /<(?:[a-z0-9_:-]+:)?([a-z0-9_.-]+)\b[^>]*>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?\1>/gi;
-const TOOL_CALL_MARKUP_ATTR_PATTERN = /(name|function|tool)\s*=\s*"([^"]+)"/i;
+const TOOL_CALL_OPEN_TAG_PATTERN = /<tool_call\b[^>]*>/gi;
+const TOOL_CALL_SINGLE_BLOCK_PATTERN = /^<(?:[a-z0-9_:-]+:)?tool_call\b([^>]*)>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?tool_call>$/i;
+const MALFORMED_TOOL_NAME_TAG_PATTERN = /<(tool_name|function_name)\s*=\s*["']([^<"']+)<\/\1>/gi;
+const TOOL_CALL_MARKUP_KV_PATTERN = /<(?:[a-z0-9_:-]+:)?([a-z0-9_.-]+)\b([^>]*)>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?([a-z0-9_.-]+)>/gi;
+const TOOL_CALL_MARKUP_ATTR_PATTERN = /(name|function|tool)\s*=\s*["']([^"']+)["']/i;
+const DIRECT_NAMED_MARKUP_PARAM_PATTERN = /<(?:[a-z0-9_:-]+:)?(?:parameter|argument)\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>\s*([\s\S]*?)(?:<\/(?:[a-z0-9_:-]+:)?(?:parameter|argument)>|(?=<(?:[a-z0-9_:-]+:)?(?:parameter|argument)\b)|(?=<(?:[a-z0-9_:-]+:)?tool_call\b)|(?=<\/(?:[a-z0-9_:-]+:)?tool_call>)|(?=<\/(?:[a-z0-9_:-]+:)?tool_calls>)|$)/gi;
+const TOOL_CALL_MARKUP_NAME_ATTR_PATTERNS = [
+  /<(?:[a-z0-9_:-]+:)?tool_name\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>/i,
+  /<(?:[a-z0-9_:-]+:)?function_name\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>/i,
+];
 const TOOL_CALL_MARKUP_NAME_PATTERNS = [
   /<(?:[a-z0-9_:-]+:)?tool_name\b[^>]*>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?tool_name>/i,
   /<(?:[a-z0-9_:-]+:)?function_name\b[^>]*>([\s\S]*?)<\/(?:[a-z0-9_:-]+:)?function_name>/i,
@@ -34,8 +42,12 @@ function stripFencedCodeBlocks(text) {
   return t.replace(/```[\s\S]*?```/g, ' ');
 }
 
+function repairMalformedToolNameTags(text) {
+  return toStringSafe(text).replace(MALFORMED_TOOL_NAME_TAG_PATTERN, '<$1>$2</$1>');
+}
+
 function parseMarkupToolCalls(text) {
-  const raw = toStringSafe(text).trim();
+  const raw = repairMalformedToolNameTags(toStringSafe(text)).trim();
   if (!raw) {
     return [];
   }
@@ -48,6 +60,64 @@ function parseMarkupToolCalls(text) {
   }
   for (const m of raw.matchAll(TOOL_CALL_MARKUP_SELFCLOSE_PATTERN)) {
     const parsed = parseMarkupSingleToolCall(toStringSafe(m[1]).trim(), '');
+    if (parsed) {
+      out.push(parsed);
+    }
+  }
+  const repaired = parseRepairedToolCallBlocks(raw);
+  if (repaired.length > out.length) {
+    return repaired;
+  }
+  return out;
+}
+
+function parseRepairedToolCallBlocks(text) {
+  const raw = toStringSafe(text).trim();
+  if (!raw) {
+    return [];
+  }
+  const lower = raw.toLowerCase();
+  const starts = [...raw.matchAll(TOOL_CALL_OPEN_TAG_PATTERN)].map((m) => m.index).filter((v) => Number.isInteger(v));
+  if (starts.length === 0) {
+    return [];
+  }
+  const out = [];
+  for (let i = 0; i < starts.length; i += 1) {
+    const start = starts[i];
+    const nextStart = i + 1 < starts.length ? starts[i + 1] : raw.length;
+    const explicitRel = lower.indexOf('</tool_call>', start);
+    const explicitEnd = explicitRel >= 0 ? explicitRel + '</tool_call>'.length : -1;
+    const wrapperRel = lower.indexOf('</tool_calls>', start);
+    const wrapperPos = wrapperRel >= 0 ? wrapperRel : -1;
+
+    let end = raw.length;
+    let implicitClose = true;
+    if (explicitEnd >= 0 && explicitEnd <= nextStart && (wrapperPos < 0 || explicitEnd <= wrapperPos)) {
+      end = explicitEnd;
+      implicitClose = false;
+    } else if (wrapperPos >= 0 && wrapperPos < nextStart) {
+      end = wrapperPos;
+    } else if (nextStart < raw.length) {
+      end = nextStart;
+    } else if (explicitEnd >= 0) {
+      end = explicitEnd;
+      implicitClose = false;
+    } else if (wrapperPos >= 0) {
+      end = wrapperPos;
+    }
+
+    let segment = raw.slice(start, end).trim();
+    if (!segment) {
+      continue;
+    }
+    if (implicitClose && !segment.toLowerCase().includes('</tool_call>')) {
+      segment += '</tool_call>';
+    }
+    const match = segment.match(TOOL_CALL_SINGLE_BLOCK_PATTERN);
+    if (!match) {
+      continue;
+    }
+    const parsed = parseMarkupSingleToolCall(toStringSafe(match[1]).trim(), toStringSafe(match[2]).trim());
     if (parsed) {
       out.push(parsed);
     }
@@ -76,7 +146,7 @@ function parseMarkupSingleToolCall(attrs, inner) {
     name = toStringSafe(attrMatch[2]).trim();
   }
   if (!name) {
-    name = extractRawTagValue(findMarkupTagValue(inner, TOOL_CALL_MARKUP_NAME_PATTERNS));
+    name = extractMarkupToolName(inner);
   }
   if (!name) {
     return null;
@@ -92,6 +162,7 @@ function parseMarkupSingleToolCall(attrs, inner) {
       input = kv;
     }
   }
+  input = mergeDirectNamedMarkupParams(input, inner);
   return { name, input };
 }
 
@@ -124,17 +195,43 @@ function parseMarkupKVObject(text) {
   }
   const out = {};
   for (const m of raw.matchAll(TOOL_CALL_MARKUP_KV_PATTERN)) {
-    const key = toStringSafe(m[1]).trim();
+    let key = toStringSafe(m[1]).trim();
+    const attrs = toStringSafe(m[2]).trim();
+    const endKey = toStringSafe(m[4]).trim();
+    if (!key || key.toLowerCase() !== endKey.toLowerCase()) {
+      continue;
+    }
+    if ((key.toLowerCase() === 'parameter' || key.toLowerCase() === 'argument') && attrs) {
+      const attrMatch = attrs.match(TOOL_CALL_MARKUP_ATTR_PATTERN);
+      if (attrMatch && attrMatch[1] && attrMatch[1].toLowerCase() === 'name' && attrMatch[2]) {
+        key = toStringSafe(attrMatch[2]).trim();
+      }
+    }
     if (!key) {
       continue;
     }
-    const value = parseMarkupValue(m[2]);
+    const value = parseMarkupValue(m[3]);
     if (value === undefined || value === null) {
       continue;
     }
     appendMarkupValue(out, key, value);
   }
   return out;
+}
+
+function extractMarkupToolName(inner) {
+  const direct = extractRawTagValue(findMarkupTagValue(inner, TOOL_CALL_MARKUP_NAME_PATTERNS));
+  if (direct) {
+    return direct;
+  }
+  const raw = toStringSafe(inner);
+  for (const pattern of TOOL_CALL_MARKUP_NAME_ATTR_PATTERNS) {
+    const match = raw.match(pattern);
+    if (match && match[1]) {
+      return toStringSafe(match[1]).trim();
+    }
+  }
+  return '';
 }
 
 function parseMarkupValue(raw) {
@@ -246,6 +343,41 @@ function appendMarkupValue(out, key, value) {
     return;
   }
   out[key] = value;
+}
+
+function clonePlainObject(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+    return {};
+  }
+  return { ...obj };
+}
+
+function mergeDirectNamedMarkupParams(base, inner) {
+  const out = clonePlainObject(base);
+  let found = false;
+  for (const match of toStringSafe(inner).matchAll(DIRECT_NAMED_MARKUP_PARAM_PATTERN)) {
+    const key = toStringSafe(match[1]).trim();
+    if (!key) {
+      continue;
+    }
+    const value = extractRawTagValue(match[2]);
+    if (!value) {
+      continue;
+    }
+    const parsed = parseToolCallInput(value);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Object.keys(parsed).length > 0 && !isOnlyRawValue(parsed)) {
+      if (!Object.prototype.hasOwnProperty.call(out, key) || JSON.stringify(out[key]) !== JSON.stringify(parsed)) {
+        appendMarkupValue(out, key, parsed);
+      }
+    } else if (!Object.prototype.hasOwnProperty.call(out, key) || JSON.stringify(out[key]) !== JSON.stringify(value)) {
+      appendMarkupValue(out, key, value);
+    }
+    found = true;
+  }
+  if (found && Object.prototype.hasOwnProperty.call(out, '_raw') && Object.keys(out).length > 1) {
+    delete out._raw;
+  }
+  return out;
 }
 
 function isOnlyRawValue(obj) {

--- a/internal/js/helpers/stream-tool-sieve/sieve-xml.js
+++ b/internal/js/helpers/stream-tool-sieve/sieve-xml.js
@@ -13,7 +13,15 @@ const XML_TOOL_TAG_PAIRS = [
 
 const XML_TOOL_OPENING_TAGS = XML_TOOL_TAG_PAIRS.map(p => p.open);
 
-function consumeXMLToolCapture(captured, toolNames, trimWrappingJSONFence) {
+function countToolCallOpenTags(text) {
+  return [...(typeof text === 'string' ? text : '').matchAll(/<tool_call\b/gi)].length;
+}
+
+function countToolCallCloseTags(text) {
+  return [...(typeof text === 'string' ? text : '').matchAll(/<\/tool_call>/gi)].length;
+}
+
+function consumeXMLToolCapture(captured, toolNames, trimWrappingJSONFence, finalize = false) {
   const lower = captured.toLowerCase();
   // Find the FIRST matching open/close pair, preferring wrapper tags.
   for (const pair of XML_TOOL_TAG_PAIRS) {
@@ -32,6 +40,9 @@ function consumeXMLToolCapture(captured, toolNames, trimWrappingJSONFence) {
     const xmlBlock = captured.slice(openIdx, closeEnd);
     let prefixPart = captured.slice(0, openIdx);
     let suffixPart = captured.slice(closeEnd);
+    if (!finalize && pair.open === '<tool_calls' && countToolCallOpenTags(xmlBlock) > countToolCallCloseTags(xmlBlock)) {
+      return { ready: false, prefix: '', calls: [], suffix: '' };
+    }
     const parsed = parseToolCalls(xmlBlock, toolNames);
     if (Array.isArray(parsed) && parsed.length > 0) {
       const trimmedFence = trimWrappingJSONFence(prefixPart, suffixPart);

--- a/internal/js/helpers/stream-tool-sieve/sieve.js
+++ b/internal/js/helpers/stream-tool-sieve/sieve.js
@@ -33,7 +33,7 @@ function processToolSieveChunk(state, chunk, toolNames) {
         state.capture += state.pending;
         state.pending = '';
       }
-      const consumed = consumeToolCapture(state, toolNames);
+      const consumed = consumeToolCapture(state, toolNames, false);
       if (!consumed.ready) {
         break;
       }
@@ -98,7 +98,7 @@ function flushToolSieve(state, toolNames) {
     state.pendingToolCalls = [];
   }
   if (state.capturing) {
-    const consumed = consumeToolCapture(state, toolNames);
+    const consumed = consumeToolCapture(state, toolNames, true);
     if (consumed.ready) {
       if (consumed.prefix) {
         noteText(state, consumed.prefix);
@@ -174,14 +174,14 @@ function findToolSegmentStart(state, s) {
   }
 }
 
-function consumeToolCapture(state, toolNames) {
+function consumeToolCapture(state, toolNames, finalize) {
   const captured = state.capture || '';
   if (!captured) {
     return { ready: false, prefix: '', calls: [], suffix: '' };
   }
 
   // XML-only tool call extraction.
-  const xmlResult = consumeXMLToolCaptureImpl(captured, toolNames, trimWrappingJSONFence);
+  const xmlResult = consumeXMLToolCaptureImpl(captured, toolNames, trimWrappingJSONFence, finalize === true);
   if (xmlResult.ready) {
     return xmlResult;
   }

--- a/internal/toolcall/regression_test.go
+++ b/internal/toolcall/regression_test.go
@@ -79,3 +79,24 @@ echo "hello"
 		})
 	}
 }
+
+func TestRegression_RepairsPrematureToolCallsWrapperClosures(t *testing.T) {
+	text := `<tool_calls>
+<tool_call>
+<tool_name>exec</tool_name>
+<parameters><command><![CDATA[pwd]]></command><timeout><![CDATA[30]]></timeout></parameters>
+</tool_calls><tool_call>
+<tool_name>memory_search</tool_name>
+<parameters><query><![CDATA[test query]]></query></parameters>
+</tool_calls>`
+	got := ParseToolCalls(text, []string{"exec", "memory_search"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 repaired calls, got %#v", got)
+	}
+	if got[0].Name != "exec" || got[0].Input["command"] != "pwd" {
+		t.Fatalf("expected repaired exec call, got %#v", got[0])
+	}
+	if got[1].Name != "memory_search" || got[1].Input["query"] != "test query" {
+		t.Fatalf("expected repaired memory_search call, got %#v", got[1])
+	}
+}

--- a/internal/toolcall/tool_prompt.go
+++ b/internal/toolcall/tool_prompt.go
@@ -54,6 +54,10 @@ RULES:
 6) Numbers, booleans, and null stay plain text.
 7) Use only the parameter names in the tool schema. Do not invent fields.
 8) Do NOT wrap XML in markdown fences. Do NOT output explanations, role markers, or internal monologue.
+9) Every argument must appear as a direct XML child inside exactly ONE <parameters> block.
+10) Never use <parameter name="...">...</parameter>.
+11) Never place arguments outside <parameters>.
+12) Do not use <invoke>, <function_call>, <function>, <tool_use>, or other alternate XML forms.
 
 PARAMETER SHAPES:
 - string => <name><![CDATA[value]]></name>
@@ -73,6 +77,12 @@ Wrong 4 — Markdown code fences:
   ` + "```xml" + `
   <tool_calls>...</tool_calls>
   ` + "```" + `
+Wrong 5 — legacy parameter tag syntax:
+  <tool_call><tool_name>` + ex1 + `</tool_name><parameter name="path">x</parameter></tool_call>
+Wrong 6 — arguments outside <parameters>:
+  <tool_call><tool_name>` + ex1 + `</tool_name><path>x</path></tool_call>
+Wrong 7 — alternate XML wrapper:
+  <invoke name="` + ex1 + `"><parameter name="path">x</parameter></invoke>
 
 Remember: The ONLY valid way to use tools is the <tool_calls> XML block at the end of your response.
 

--- a/internal/toolcall/toolcalls_markup.go
+++ b/internal/toolcall/toolcalls_markup.go
@@ -3,6 +3,7 @@ package toolcall
 import (
 	"encoding/json"
 	"html"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -14,8 +15,13 @@ var toolCallMarkupTagPatternByName = map[string]*regexp.Regexp{
 	"invoke":        regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?invoke\b([^>]*)>(.*?)</(?:[a-z0-9_:-]+:)?invoke>`),
 }
 var toolCallMarkupSelfClosingPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?invoke\b([^>]*)/>`)
-var toolCallMarkupKVPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?([a-z0-9_\-.]+)\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?([a-z0-9_\-.]+)>`)
-var toolCallMarkupAttrPattern = regexp.MustCompile(`(?is)(name|function|tool)\s*=\s*"([^"]+)"`)
+var toolCallMarkupKVPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?([a-z0-9_\-.]+)\b([^>]*)>(.*?)</(?:[a-z0-9_:-]+:)?([a-z0-9_\-.]+)>`)
+var toolCallMarkupAttrPattern = regexp.MustCompile(`(?is)(name|function|tool)\s*=\s*["']([^"']+)["']`)
+var directNamedMarkupParamOpenPattern = regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?(?:parameter|argument)\b([^>]*)>`)
+var toolCallMarkupInnerNameAttrPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?tool_name\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>`),
+	regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?function_name\b[^>]*\bname\s*=\s*["']([^"']+)["'][^>]*>`),
+}
 var anyTagPattern = regexp.MustCompile(`(?is)<[^>]+>`)
 var toolCallMarkupNameTagNames = []string{"name", "function"}
 var toolCallMarkupNamePatternByTag = map[string]*regexp.Regexp{
@@ -103,7 +109,7 @@ func parseMarkupSingleToolCall(attrs string, inner string) ParsedToolCall {
 		name = strings.TrimSpace(m[2])
 	}
 	if name == "" {
-		name = findMarkupTagValue(inner, toolCallMarkupNameTagNames, toolCallMarkupNamePatternByTag)
+		name = extractMarkupToolName(inner)
 	}
 	if name == "" {
 		return ParsedToolCall{}
@@ -115,6 +121,7 @@ func parseMarkupSingleToolCall(attrs string, inner string) ParsedToolCall {
 	} else if kv := parseMarkupKVObject(inner); len(kv) > 0 {
 		input = kv
 	}
+	input = mergeDirectNamedMarkupParams(input, inner)
 	return ParsedToolCall{Name: name, Input: input}
 }
 
@@ -129,19 +136,25 @@ func parseMarkupKVObject(text string) map[string]any {
 	}
 	out := map[string]any{}
 	for _, m := range matches {
-		if len(m) < 4 {
+		if len(m) < 5 {
 			continue
 		}
 		key := strings.TrimSpace(m[1])
-		endKey := strings.TrimSpace(m[3])
+		attrs := strings.TrimSpace(m[2])
+		endKey := strings.TrimSpace(m[4])
 		if key == "" {
 			continue
 		}
 		if !strings.EqualFold(key, endKey) {
 			continue
 		}
-		value := parseMarkupValue(m[2])
-		if value == nil {
+		if strings.EqualFold(key, "parameter") || strings.EqualFold(key, "argument") {
+			if attrMatch := toolCallMarkupAttrPattern.FindStringSubmatch(attrs); len(attrMatch) >= 3 && strings.EqualFold(attrMatch[1], "name") {
+				key = strings.TrimSpace(attrMatch[2])
+			}
+		}
+		value := parseMarkupValue(m[3])
+		if value == nil || strings.TrimSpace(key) == "" {
 			continue
 		}
 		appendMarkupValue(out, key, value)
@@ -150,6 +163,77 @@ func parseMarkupKVObject(text string) map[string]any {
 		return nil
 	}
 	return out
+}
+
+func extractMarkupToolName(inner string) string {
+	name := findMarkupTagValue(inner, toolCallMarkupNameTagNames, toolCallMarkupNamePatternByTag)
+	if name != "" {
+		return name
+	}
+	for _, pattern := range toolCallMarkupInnerNameAttrPatterns {
+		if m := pattern.FindStringSubmatch(inner); len(m) >= 2 {
+			if v := strings.TrimSpace(html.UnescapeString(m[1])); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+func mergeDirectNamedMarkupParams(base map[string]any, inner string) map[string]any {
+ out := map[string]any{}
+ for k, v := range base {
+ out[k] = v
+ }
+ found := false
+ lower := strings.ToLower(inner)
+ matches := directNamedMarkupParamOpenPattern.FindAllStringSubmatchIndex(inner, -1)
+ for _, loc := range matches {
+ if len(loc) < 4 {
+ continue
+ }
+ attrs := inner[loc[2]:loc[3]]
+ attrMatch := toolCallMarkupAttrPattern.FindStringSubmatch(attrs)
+ if len(attrMatch) < 3 || !strings.EqualFold(strings.TrimSpace(attrMatch[1]), "name") {
+ continue
+ }
+ key := strings.TrimSpace(html.UnescapeString(attrMatch[2]))
+ if key == "" {
+ continue
+ }
+ bodyStart := loc[1]
+ restLower := lower[bodyStart:]
+ end := len(inner)
+ for _, marker := range []string{"</parameter>", "</argument>", "<parameter", "<argument", "<tool_call", "</tool_call>", "</tool_calls>"} {
+ idx := strings.Index(restLower, marker)
+ if idx >= 0 && bodyStart+idx < end {
+ end = bodyStart + idx
+ }
+ }
+ value := extractRawTagValue(inner[bodyStart:end])
+ if parsed := parseStructuredToolCallInput(value); len(parsed) > 0 {
+ if isOnlyRawValue(parsed, value) {
+ if existing, ok := out[key]; !ok || !reflect.DeepEqual(existing, value) {
+ appendMarkupValue(out, key, value)
+ }
+ } else {
+ if existing, ok := out[key]; !ok || !reflect.DeepEqual(existing, parsed) {
+ appendMarkupValue(out, key, parsed)
+ }
+ }
+ } else if strings.TrimSpace(value) != "" {
+ if existing, ok := out[key]; !ok || !reflect.DeepEqual(existing, value) {
+ appendMarkupValue(out, key, value)
+ }
+ }
+ found = true
+ }
+ if found {
+ if _, ok := out["_raw"]; ok && len(out) > 1 {
+ delete(out, "_raw")
+ }
+ }
+ return out
 }
 
 func parseMarkupValue(inner string) any {

--- a/internal/toolcall/toolcalls_parse_markup.go
+++ b/internal/toolcall/toolcalls_parse_markup.go
@@ -23,8 +23,29 @@ var xmlToolNamePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?tool_name\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?tool_name>`),
 	regexp.MustCompile(`(?is)<(?:[a-z0-9_:-]+:)?function_name\b[^>]*>(.*?)</(?:[a-z0-9_:-]+:)?function_name>`),
 }
+var xmlToolCallOpenPattern = regexp.MustCompile(`(?is)<tool_call\b[^>]*>`)
+var malformedXMLToolNameTagPattern = regexp.MustCompile(`(?is)<(?:tool_name|function_name)\s*=\s*["']([^<"']+)</(?:tool_name|function_name)>`)
+
+func repairMalformedXMLToolNameTags(text string) string {
+	if text == "" {
+		return text
+	}
+	return malformedXMLToolNameTagPattern.ReplaceAllStringFunc(text, func(match string) string {
+		lower := strings.ToLower(match)
+		tag := "tool_name"
+		if strings.Contains(lower, "<function_name") {
+			tag = "function_name"
+		}
+		submatches := malformedXMLToolNameTagPattern.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		return "<" + tag + ">" + submatches[1] + "</" + tag + ">"
+	})
+}
 
 func parseXMLToolCalls(text string) []ParsedToolCall {
+	text = repairMalformedXMLToolNameTags(text)
 	matches := xmlToolCallPattern.FindAllString(text, -1)
 	out := make([]ParsedToolCall, 0, len(matches)+1)
 	for _, block := range matches {
@@ -34,8 +55,15 @@ func parseXMLToolCalls(text string) []ParsedToolCall {
 		}
 		out = append(out, call)
 	}
+	repaired := parseRepairedXMLToolCalls(text)
+	if len(repaired) > len(out) {
+		return repaired
+	}
 	if len(out) > 0 {
 		return out
+	}
+	if len(repaired) > 0 {
+		return repaired
 	}
 	if call, ok := parseFunctionCallTagStyle(text); ok {
 		return []ParsedToolCall{call}
@@ -59,6 +87,63 @@ func parseXMLToolCalls(text string) []ParsedToolCall {
 		return []ParsedToolCall{call}
 	}
 	return nil
+}
+
+func parseRepairedXMLToolCalls(text string) []ParsedToolCall {
+	starts := xmlToolCallOpenPattern.FindAllStringIndex(text, -1)
+	if len(starts) == 0 {
+		return nil
+	}
+	lower := strings.ToLower(text)
+	out := make([]ParsedToolCall, 0, len(starts))
+	for i, loc := range starts {
+		start := loc[0]
+		nextStart := len(text)
+		if i+1 < len(starts) {
+			nextStart = starts[i+1][0]
+		}
+
+		explicitEnd := -1
+		if idx := strings.Index(lower[start:], "</tool_call>"); idx >= 0 {
+			explicitEnd = start + idx + len("</tool_call>")
+		}
+		wrapperClose := -1
+		if idx := strings.Index(lower[start:], "</tool_calls>"); idx >= 0 {
+			wrapperClose = start + idx
+		}
+
+		end := len(text)
+		implicitClose := true
+		switch {
+		case explicitEnd >= 0 && explicitEnd <= nextStart && (wrapperClose < 0 || explicitEnd <= wrapperClose):
+			end = explicitEnd
+			implicitClose = false
+		case wrapperClose >= 0 && wrapperClose < nextStart:
+			end = wrapperClose
+		case nextStart < len(text):
+			end = nextStart
+		case explicitEnd >= 0:
+			end = explicitEnd
+			implicitClose = false
+		case wrapperClose >= 0:
+			end = wrapperClose
+		}
+
+		segment := strings.TrimSpace(text[start:end])
+		if segment == "" {
+			continue
+		}
+		if implicitClose && !strings.Contains(strings.ToLower(segment), "</tool_call>") {
+			segment += "</tool_call>"
+		}
+		if call, ok := parseSingleXMLToolCall(segment); ok {
+			out = append(out, call)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
@@ -152,6 +237,7 @@ func parseSingleXMLToolCall(block string) (ParsedToolCall, bool) {
 	if strings.TrimSpace(name) == "" {
 		name = strings.TrimSpace(html.UnescapeString(extractXMLToolNameByRegex(stripTopLevelXMLParameters(inner))))
 	}
+		params = mergeDirectNamedMarkupParams(params, inner)
 	if strings.TrimSpace(name) == "" {
 		return ParsedToolCall{}, false
 	}
@@ -187,6 +273,9 @@ func extractXMLToolNameByRegex(inner string) string {
 				return v
 			}
 		}
+	}
+	if v := strings.TrimSpace(extractMarkupToolName(inner)); v != "" {
+		return v
 	}
 	return ""
 }

--- a/internal/toolcall/toolcalls_xml.go
+++ b/internal/toolcall/toolcalls_xml.go
@@ -101,7 +101,16 @@ func parseXMLNodeValue(dec *xml.Decoder, start xml.StartElement) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			appendXMLChildValue(children, t.Name.Local, child)
+			key := t.Name.Local
+			if (strings.EqualFold(key, "parameter") || strings.EqualFold(key, "argument")) && len(t.Attr) > 0 {
+				for _, attr := range t.Attr {
+					if strings.EqualFold(attr.Name.Local, "name") && strings.TrimSpace(attr.Value) != "" {
+						key = strings.TrimSpace(attr.Value)
+						break
+					}
+				}
+			}
+			appendXMLChildValue(children, key, child)
 		case xml.EndElement:
 			if t.Name.Local != start.Name.Local {
 				return nil, errXMLMismatch(start.Name.Local, t.Name.Local)

--- a/tests/node/stream-tool-sieve.test.js
+++ b/tests/node/stream-tool-sieve.test.js
@@ -155,6 +155,24 @@ test('sieve passes malformed executable-looking XML through as text', () => {
   assert.equal(leakedText, chunk);
 });
 
+test('sieve repairs malformed repeated tool_calls wrapper closures on flush', () => {
+  const events = runSieve(
+    [
+      '<tool_calls>\n<tool_call>\n<tool_name>exec</tool_name>\n<parameters><command><![CDATA[pwd]]></command></parameters>\n</tool_calls>',
+      '<tool_call>\n<tool_name>memory_search</tool_name>\n<parameters><query><![CDATA[test query]]></query></parameters>\n</tool_calls>',
+    ],
+    ['exec', 'memory_search'],
+  );
+  const leakedText = collectText(events);
+  const finalCalls = events.filter((evt) => evt.type === 'tool_calls').flatMap((evt) => evt.calls || []);
+  assert.equal(leakedText, '');
+  assert.equal(finalCalls.length, 2);
+  assert.equal(finalCalls[0].name, 'exec');
+  assert.equal(finalCalls[0].input.command, 'pwd');
+  assert.equal(finalCalls[1].name, 'memory_search');
+  assert.equal(finalCalls[1].input.query, 'test query');
+});
+
 test('sieve flushes incomplete captured XML tool blocks by falling back to raw text', () => {
   const events = runSieve(
     [


### PR DESCRIPTION
变更概述

这个 PR 主要修复 `ds2api` 在工具调用（tool call）场景下的一组流式解析与运行时问题，重点包括：

1. 收紧并统一 XML 工具调用输出格式
2. 修复流式输出时 `<tool_calls>` / `<tool_call>` 包装错位、提前闭合、分片断裂导致的解析失败
3. 修复工具调用重复触发问题
4. 清理泄漏到可见文本中的工具调用 XML 残片
5. 补齐部分 `responses` / runtime 路径下的工具调用处理一致性


具体修改
1. 收紧 canonical XML tool-call 规范
- 关闭过早 `emitEarlyToolDeltas`
- 强化 tool prompt 约束
- 明确要求工具调用使用统一 XML 结构：
  - 使用 `<tool_calls>` / `<tool_call>`
  - 参数统一放在单个 `<parameters>` 中
- 明确限制非规范写法，减少模型输出脏格式导致的后续解析问题

2. 修复流式 XML 工具调用包装恢复
- 修复流式返回过程中 `<tool_calls>` / `<tool_call>` 因分块、提前闭合、包装错位导致的解析异常
- 改进 flush/finalize 阶段的恢复逻辑
- 增强 tool sieve 与 XML 捕获逻辑，减少半截工具调用被误判或漏判

3. 修复脏 XML / 非标准参数写法兼容
- 改进对部分非标准工具调用标记的恢复能力
- 增强 `tool_name`、参数标签、命名参数等解析逻辑
- 提高对不完全规范 XML 输出的容错性

4. 修复工具调用重复触发
- 增加 tool call 去重逻辑
- 避免同一工具调用在 streaming/runtime 过程中被重复发出

 5. 清理 leaked tool markup
- 清理泄漏到用户可见文本中的工具调用 XML 片段，例如：
  - `<tool_calls>`
  - `</tool_calls>`
  - `</tool_call>`
  - 其他残留 closing fragment
- 避免前端/调用方看到不应暴露的工具调用内部标记

6. 补齐 responses/runtime 路径处理
- 调整部分 `responses` runtime 路径下的工具调用和可见文本处理
- 让工具调用解析、可见文本输出、残片清理行为更加一致


提交拆分
本次改动按 3 个提交整理：

1. **Enforce canonical XML tool-call shape**
   收紧工具调用规范与提示约束

2. **Repair streamed XML tool-call parsing and wrapper recovery**
   修复流式 XML 工具调用解析与包装恢复

3. **Deduplicate tool calls and strip leaked tool markup**
   修复重复工具调用与工具调用标记泄漏问题


影响范围
主要涉及：
- `internal/toolcall/*`
- `internal/adapter/openai/tool_sieve_*`
- `internal/adapter/openai/*runtime*`
- `internal/js/helpers/stream-tool-sieve/*`
- `internal/js/chat-stream/*`
- `tests/node/stream-tool-sieve.test.js`


 预期效果
合入后，工具调用链路应当具备更好的稳定性与容错性，具体表现为：

- 更少出现流式工具调用丢失、断裂、误解析
- 更少出现 `<tool_calls>` / `</tool_call>` 等 XML 残片泄漏到用户可见内容
- 减少重复工具调用事件
- 提升 `chat` / `responses` 路径下工具调用处理的一致性
