### PR TITLE
修复思维链 tool_calls 泄漏与空输出误判

### DIFF
--- a/docs/fix-toolcall-in-thinking.md
+++ b/docs/fix-toolcall-in-thinking.md
@@ -10,7 +10,7 @@ DeepSeek 模型在推理过程中（thinking/reasoning）输出工具调用时�
 2. 流式路径 `finalize()` 仅对 `s.text` 做工具调用解析，忽略 `s.thinking`
 3. 非流式路径 `BuildChatCompletion()` 仅对 `finalText` 解析
 4. 空输出检查只认 `finalText == ""`，未考虑 thinking 中的工具调用
-5. `sanitizeLeakedOutput()` 未清理 `<tool_calls>` XML
+5. 流式 reasoning 增量直发，未对 `<tool_calls>` XML 做流式筛分
 6. `/v1/responses` 路径同样存在此问题
 
 ## 影响范围
@@ -64,13 +64,13 @@ if len(detected.Calls) == 0 {
 }
 ```
 
-### 步骤 4: leis_resource.go — 添加 cleanToolCallXML 清理
+### 步骤 4: shared/leaked_output_sanitize.go — 添加 `CleanToolCallXML()`
 
-添加 `cleanToolCallXML()` 函数，用正则去除 `<tool_calls>...</tool_calls>` 块。
+添加 `CleanToolCallXML()` 函数，用正则去除 `<tool_calls>...</tool_calls>` 块，但只在**已经成功检测到工具调用之后**用于清理最终暴露的 reasoning 文本。
 
-### 步骤 5: leaked_output_sanitize.go — 增加 XML 清理规则
+### 步骤 5: 流式 thinking 走筛分后再发
 
-新增 `leakedToolCallXMLPattern`，防止任何路径泄露原始工具调用 XML。
+不要把 `<tool_calls>` 清理塞进通用 `sanitizeLeakedOutput()` / `CleanVisibleOutput()` 链路，否则会在检测前把合法工具调用删掉。流式链路应缓存 thinking 原文用于检测，同时只把经筛分后的非工具文本作为 `reasoning_content` 发给客户端。
 
 ### 步骤 6: /v1/responses 路径同步修复
 

--- a/docs/fix-toolcall-in-thinking.md
+++ b/docs/fix-toolcall-in-thinking.md
@@ -1,0 +1,91 @@
+# 修复: 模型思维链中出现工具调用时报错
+
+## 问题概述
+
+DeepSeek 模型在推理过程中（thinking/reasoning）输出工具调用时，SSE 片段类型为 `THINK` 而非 `RESPONSE`，导致 ds2api 无法检测到工具调用并报 "empty output" 错误。
+
+## 根因
+
+1. SSE 解析器 `splitThinkingParts()` 仅按 `</think>` 分割 thinking/text，不处理 `<tool_calls>`
+2. 流式路径 `finalize()` 仅对 `s.text` 做工具调用解析，忽略 `s.thinking`
+3. 非流式路径 `BuildChatCompletion()` 仅对 `finalText` 解析
+4. 空输出检查只认 `finalText == ""`，未考虑 thinking 中的工具调用
+5. `sanitizeLeakedOutput()` 未清理 `<tool_calls>` XML
+6. `/v1/responses` 路径同样存在此问题
+
+## 影响范围
+
+- 流式模式: 工具调用出现在 thinking 中时 → 429 "empty output" 错误
+- 非流式模式: 工具调用静默丢失
+- 所有路径: reasoning_content 泄露原始 XML
+
+## 修复步骤
+
+### 步骤 1: chat_stream_runtime.go — finalize() 增加 thinking fallback
+
+在 `finalize()` 中，如果 `finalText` 未检测到工具调用，则对 `finalThinking` 执行 fallback 检测:
+
+```go
+detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
+if len(detected.Calls) == 0 {
+    detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
+    if len(detected.Calls) > 0 {
+        finalThinking = cleanToolCallXML(finalThinking)
+        s.finalThinking = finalThinking
+    }
+}
+```
+
+### 步骤 2: handler_chat.go — handleNonStream() 增加 thinking fallback
+
+在 `shouldWriteUpstreamEmptyOutputError(finalText)` 之前增加 thinking 工具调用检测:
+
+```go
+if shouldWriteUpstreamEmptyOutputError(finalText) {
+    detected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+    if len(detected.Calls) > 0 {
+        finalThinking = cleanToolCallXML(finalThinking)
+        // 继续执行 BuildChatCompletion
+    } else {
+        // 原空输出错误逻辑
+    }
+}
+```
+
+### 步骤 3: render_chat.go — BuildChatCompletion() 增加 thinking fallback
+
+```go
+detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
+if len(detected.Calls) == 0 {
+    detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+    if len(detected.Calls) > 0 {
+        finalThinking = cleanToolCallXML(finalThinking)
+    }
+}
+```
+
+### 步骤 4: leis_resource.go — 添加 cleanToolCallXML 清理
+
+添加 `cleanToolCallXML()` 函数，用正则去除 `<tool_calls>...</tool_calls>` 块。
+
+### 步骤 5: leaked_output_sanitize.go — 增加 XML 清理规则
+
+新增 `leakedToolCallXMLPattern`，防止任何路径泄露原始工具调用 XML。
+
+### 步骤 6: /v1/responses 路径同步修复
+
+- `responses_handler.go`: `handleNonStreamResponses()` 同样修复
+- `responses_stream_runtime_core.go`: `finalizeResponses()` 同样修复
+- `render_responses.go`: `BuildResponseObject()` 同样修复
+
+### 步骤 7: 回归测试
+
+在 `handler_toolcall_test.go` 中添加 thinking 含工具调用的测试用例。
+
+## 验证方法
+
+```bash
+go build ./...
+go test ./internal/httpapi/openai/chat/...
+go test ./internal/httpapi/openai/responses/...
+```

--- a/internal/format/openai/render_chat.go
+++ b/internal/format/openai/render_chat.go
@@ -14,7 +14,7 @@ func BuildChatCompletion(completionID, model, finalPrompt, finalThinking, finalT
 	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
 		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
 		if len(detected.Calls) > 0 {
-			finalThinking = cleanToolCallXML(finalThinking)
+			finalThinking = shared.CleanToolCallXML(finalThinking)
 		}
 	}
 	finishReason := "stop"

--- a/internal/format/openai/render_chat.go
+++ b/internal/format/openai/render_chat.go
@@ -8,15 +8,7 @@ import (
 )
 
 func BuildChatCompletion(completionID, model, finalPrompt, finalThinking, finalText string, toolNames []string) map[string]any {
-	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
-	// Fallback: if text has no tool calls, check thinking content.
-	// DeepSeek may emit <tool_calls> XML inside thinking fragments.
-	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
-		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
-		if len(detected.Calls) > 0 {
-			finalThinking = shared.CleanToolCallXML(finalThinking)
-		}
-	}
+	detected, finalThinking := shared.DetectToolCallsWithThinkingFallback(finalText, finalThinking, finalThinking, toolNames)
 	finishReason := "stop"
 	messageObj := map[string]any{"role": "assistant", "content": finalText}
 	if strings.TrimSpace(finalThinking) != "" {

--- a/internal/format/openai/render_chat.go
+++ b/internal/format/openai/render_chat.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/toolcall"
 	"strings"
 	"time"
@@ -8,6 +9,14 @@ import (
 
 func BuildChatCompletion(completionID, model, finalPrompt, finalThinking, finalText string, toolNames []string) map[string]any {
 	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
+	// Fallback: if text has no tool calls, check thinking content.
+	// DeepSeek may emit <tool_calls> XML inside thinking fragments.
+	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
+		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+		if len(detected.Calls) > 0 {
+			finalThinking = cleanToolCallXML(finalThinking)
+		}
+	}
 	finishReason := "stop"
 	messageObj := map[string]any{"role": "assistant", "content": finalText}
 	if strings.TrimSpace(finalThinking) != "" {

--- a/internal/format/openai/render_responses.go
+++ b/internal/format/openai/render_responses.go
@@ -18,7 +18,7 @@ func BuildResponseObject(responseID, model, finalPrompt, finalThinking, finalTex
 	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
 		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
 		if len(detected.Calls) > 0 {
-			finalThinking = shared.cleanToolCallXML(finalThinking)
+			finalThinking = shared.CleanToolCallXML(finalThinking)
 		}
 	}
 	exposedOutputText := finalText

--- a/internal/format/openai/render_responses.go
+++ b/internal/format/openai/render_responses.go
@@ -13,14 +13,7 @@ import (
 func BuildResponseObject(responseID, model, finalPrompt, finalThinking, finalText string, toolNames []string) map[string]any {
 	// Strict mode: only standalone, structured tool-call payloads are treated
 	// as executable tool calls.
-	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
-	// Fallback: if text has no tool calls, check thinking content.
-	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
-		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
-		if len(detected.Calls) > 0 {
-			finalThinking = shared.CleanToolCallXML(finalThinking)
-		}
-	}
+	detected, finalThinking := shared.DetectToolCallsWithThinkingFallback(finalText, finalThinking, finalThinking, toolNames)
 	exposedOutputText := finalText
 	output := make([]any, 0, 2)
 	if len(detected.Calls) > 0 {

--- a/internal/format/openai/render_responses.go
+++ b/internal/format/openai/render_responses.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/toolcall"
 	"encoding/json"
 	"strings"
@@ -13,6 +14,13 @@ func BuildResponseObject(responseID, model, finalPrompt, finalThinking, finalTex
 	// Strict mode: only standalone, structured tool-call payloads are treated
 	// as executable tool calls.
 	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
+	// Fallback: if text has no tool calls, check thinking content.
+	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
+		detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+		if len(detected.Calls) > 0 {
+			finalThinking = shared.cleanToolCallXML(finalThinking)
+		}
+	}
 	exposedOutputText := finalText
 	output := make([]any, 0, 2)
 	if len(detected.Calls) > 0 {

--- a/internal/httpapi/openai/chat/chat_stream_runtime.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime.go
@@ -141,7 +141,7 @@ func (s *chatStreamRuntime) finalize(finishReason string) {
 		thinkingDetected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
 		if len(thinkingDetected.Calls) > 0 {
 			detected = thinkingDetected
-			finalThinking = shared.cleanToolCallXML(finalThinking)
+			finalThinking = shared.CleanToolCallXML(finalThinking)
 		}
 	}
 	s.finalThinking = finalThinking

--- a/internal/httpapi/openai/chat/chat_stream_runtime.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"ds2api/internal/toolcall"
 	"encoding/json"
 	"net/http"
 	"strings"

--- a/internal/httpapi/openai/chat/chat_stream_runtime.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	openaifmt "ds2api/internal/format/openai"
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/sse"
 	streamengine "ds2api/internal/stream"
 	"ds2api/internal/toolstream"
@@ -131,9 +132,20 @@ func (s *chatStreamRuntime) resetStreamToolCallState() {
 func (s *chatStreamRuntime) finalize(finishReason string) {
 	finalThinking := s.thinking.String()
 	finalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
+	s.finalText = finalText
+
+	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
+	// Fallback: if text has no tool calls, check thinking content.
+	// DeepSeek may emit <tool_calls> XML inside thinking fragments.
+	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
+		thinkingDetected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
+		if len(thinkingDetected.Calls) > 0 {
+			detected = thinkingDetected
+			finalThinking = shared.cleanToolCallXML(finalThinking)
+		}
+	}
 	s.finalThinking = finalThinking
 	s.finalText = finalText
-	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
 	if len(detected.Calls) > 0 && !s.toolCallsDoneEmitted {
 		finishReason = "tool_calls"
 		delta := map[string]any{

--- a/internal/httpapi/openai/chat/chat_stream_runtime.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime.go
@@ -37,7 +37,9 @@ type chatStreamRuntime struct {
 	toolSieve         toolstream.State
 	streamToolCallIDs map[int]string
 	streamToolNames   map[int]string
-	thinking          strings.Builder
+	thinkingSieve     toolstream.State
+	thinkingRaw       strings.Builder
+	thinkingVisible   strings.Builder
 	text              strings.Builder
 
 	finalThinking     string
@@ -130,20 +132,13 @@ func (s *chatStreamRuntime) resetStreamToolCallState() {
 }
 
 func (s *chatStreamRuntime) finalize(finishReason string) {
-	finalThinking := s.thinking.String()
+	s.flushThinking()
+	finalThinkingRaw := s.thinkingRaw.String()
+	finalThinking := s.thinkingVisible.String()
 	finalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
 	s.finalText = finalText
 
-	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
-	// Fallback: if text has no tool calls, check thinking content.
-	// DeepSeek may emit <tool_calls> XML inside thinking fragments.
-	if len(detected.Calls) == 0 && strings.Contains(finalThinking, "<tool_calls") {
-		thinkingDetected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
-		if len(thinkingDetected.Calls) > 0 {
-			detected = thinkingDetected
-			finalThinking = shared.CleanToolCallXML(finalThinking)
-		}
-	}
+	detected, finalThinking := shared.DetectToolCallsWithThinkingFallback(finalText, finalThinkingRaw, finalThinking, s.toolNames)
 	s.finalThinking = finalThinking
 	s.finalText = finalText
 	if len(detected.Calls) > 0 && !s.toolCallsDoneEmitted {
@@ -259,20 +254,29 @@ func (s *chatStreamRuntime) onParsed(parsed sse.LineResult) streamengine.ParsedD
 			continue
 		}
 		contentSeen = true
-		delta := map[string]any{}
-		if !s.firstChunkSent {
-			delta["role"] = "assistant"
-			s.firstChunkSent = true
-		}
 		if p.Type == "thinking" {
-			if s.thinkingEnabled {
-				trimmed := sse.TrimContinuationOverlap(s.thinking.String(), cleanedText)
-				if trimmed == "" {
-					continue
-				}
-				s.thinking.WriteString(trimmed)
-				delta["reasoning_content"] = trimmed
+			trimmed := sse.TrimContinuationOverlap(s.thinkingRaw.String(), cleanedText)
+			if trimmed == "" {
+				continue
 			}
+			s.thinkingRaw.WriteString(trimmed)
+			if s.thinkingEnabled {
+				for _, evt := range toolstream.ProcessChunk(&s.thinkingSieve, trimmed, s.toolNames) {
+					if evt.Content == "" {
+						continue
+					}
+					s.thinkingVisible.WriteString(evt.Content)
+					delta := map[string]any{
+						"reasoning_content": evt.Content,
+					}
+					if !s.firstChunkSent {
+						delta["role"] = "assistant"
+						s.firstChunkSent = true
+					}
+					newChoices = append(newChoices, openaifmt.BuildChatStreamDeltaChoice(0, delta))
+				}
+			}
+			continue
 		} else {
 			trimmed := sse.TrimContinuationOverlap(s.text.String(), cleanedText)
 			if trimmed == "" {
@@ -280,7 +284,13 @@ func (s *chatStreamRuntime) onParsed(parsed sse.LineResult) streamengine.ParsedD
 			}
 			s.text.WriteString(trimmed)
 			if !s.bufferToolContent {
+				delta := map[string]any{}
+				if !s.firstChunkSent {
+					delta["role"] = "assistant"
+					s.firstChunkSent = true
+				}
 				delta["content"] = trimmed
+				newChoices = append(newChoices, openaifmt.BuildChatStreamDeltaChoice(0, delta))
 			} else {
 				events := toolstream.ProcessChunk(&s.toolSieve, trimmed, s.toolNames)
 				for _, evt := range events {
@@ -338,13 +348,36 @@ func (s *chatStreamRuntime) onParsed(parsed sse.LineResult) streamengine.ParsedD
 				}
 			}
 		}
-		if len(delta) > 0 {
-			newChoices = append(newChoices, openaifmt.BuildChatStreamDeltaChoice(0, delta))
-		}
 	}
 
 	if len(newChoices) > 0 {
 		s.sendChunk(openaifmt.BuildChatStreamChunk(s.completionID, s.created, s.model, newChoices, nil))
 	}
 	return streamengine.ParsedDecision{ContentSeen: contentSeen}
+}
+
+func (s *chatStreamRuntime) flushThinking() {
+	if !s.thinkingEnabled {
+		return
+	}
+	for _, evt := range toolstream.Flush(&s.thinkingSieve, s.toolNames) {
+		if evt.Content == "" {
+			continue
+		}
+		s.thinkingVisible.WriteString(evt.Content)
+		delta := map[string]any{
+			"reasoning_content": evt.Content,
+		}
+		if !s.firstChunkSent {
+			delta["role"] = "assistant"
+			s.firstChunkSent = true
+		}
+		s.sendChunk(openaifmt.BuildChatStreamChunk(
+			s.completionID,
+			s.created,
+			s.model,
+			[]map[string]any{openaifmt.BuildChatStreamDeltaChoice(0, delta)},
+			nil,
+		))
+	}
 }

--- a/internal/httpapi/openai/chat/handler_chat.go
+++ b/internal/httpapi/openai/chat/handler_chat.go
@@ -16,7 +16,6 @@ import (
 	"ds2api/internal/promptcompat"
 	"ds2api/internal/sse"
 	streamengine "ds2api/internal/stream"
-	"ds2api/internal/toolcall"
 )
 
 func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
@@ -164,28 +163,14 @@ func (h *Handler) handleNonStream(w http.ResponseWriter, resp *http.Response, co
 	if searchEnabled {
 		finalText = replaceCitationMarkersWithLinks(finalText, result.CitationLinks)
 	}
-	if shouldWriteUpstreamEmptyOutputError(finalText) {
-		// Fallback: check if thinking content contains tool calls
-		if strings.Contains(finalThinking, "<tool_calls") {
-			detected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
-			if len(detected.Calls) > 0 {
-				finalThinking = shared.CleanToolCallXML(finalThinking)
-			} else {
-				status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
-				if historySession != nil {
-					historySession.error(status, message, code, finalThinking, finalText)
-				}
-				writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
-				return
-			}
-		} else {
-			status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
-			if historySession != nil {
-				historySession.error(status, message, code, finalThinking, finalText)
-			}
-			writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
-			return
+	detected, finalThinking := shared.DetectToolCallsWithThinkingFallback(finalText, finalThinking, finalThinking, toolNames)
+	if shouldWriteUpstreamEmptyOutputError(finalText) && len(detected.Calls) == 0 {
+		status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
+		if historySession != nil {
+			historySession.error(status, message, code, finalThinking, finalText)
 		}
+		writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
+		return
 	}
 	respBody := openaifmt.BuildChatCompletion(completionID, model, finalPrompt, finalThinking, finalText, toolNames)
 	finishReason := "stop"

--- a/internal/httpapi/openai/chat/handler_chat.go
+++ b/internal/httpapi/openai/chat/handler_chat.go
@@ -245,7 +245,7 @@ func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, resp *htt
 		OnParsed: func(parsed sse.LineResult) streamengine.ParsedDecision {
 			decision := streamRuntime.onParsed(parsed)
 			if historySession != nil {
-				historySession.progress(streamRuntime.thinking.String(), streamRuntime.text.String())
+				historySession.progress(streamRuntime.thinkingVisible.String(), streamRuntime.text.String())
 			}
 			return decision
 		},
@@ -259,14 +259,14 @@ func (h *Handler) handleStream(w http.ResponseWriter, r *http.Request, resp *htt
 				return
 			}
 			if streamRuntime.finalErrorMessage != "" {
-				historySession.error(streamRuntime.finalErrorStatus, streamRuntime.finalErrorMessage, streamRuntime.finalErrorCode, streamRuntime.thinking.String(), streamRuntime.text.String())
+				historySession.error(streamRuntime.finalErrorStatus, streamRuntime.finalErrorMessage, streamRuntime.finalErrorCode, streamRuntime.thinkingVisible.String(), streamRuntime.text.String())
 				return
 			}
 			historySession.success(http.StatusOK, streamRuntime.finalThinking, streamRuntime.finalText, streamRuntime.finalFinishReason, streamRuntime.finalUsage)
 		},
 		OnContextDone: func() {
 			if historySession != nil {
-				historySession.stopped(streamRuntime.thinking.String(), streamRuntime.text.String(), string(streamengine.StopReasonContextCancelled))
+				historySession.stopped(streamRuntime.thinkingVisible.String(), streamRuntime.text.String(), string(streamengine.StopReasonContextCancelled))
 			}
 		},
 	})

--- a/internal/httpapi/openai/chat/handler_chat.go
+++ b/internal/httpapi/openai/chat/handler_chat.go
@@ -169,7 +169,7 @@ func (h *Handler) handleNonStream(w http.ResponseWriter, resp *http.Response, co
 		if strings.Contains(finalThinking, "<tool_calls") {
 			detected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
 			if len(detected.Calls) > 0 {
-				finalThinking = shared.cleanToolCallXML(finalThinking)
+				finalThinking = shared.CleanToolCallXML(finalThinking)
 			} else {
 				status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
 				if historySession != nil {

--- a/internal/httpapi/openai/chat/handler_chat.go
+++ b/internal/httpapi/openai/chat/handler_chat.go
@@ -12,9 +12,11 @@ import (
 	"ds2api/internal/config"
 	dsprotocol "ds2api/internal/deepseek/protocol"
 	openaifmt "ds2api/internal/format/openai"
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/promptcompat"
 	"ds2api/internal/sse"
 	streamengine "ds2api/internal/stream"
+	"ds2api/internal/toolcall"
 )
 
 func (h *Handler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
@@ -163,12 +165,27 @@ func (h *Handler) handleNonStream(w http.ResponseWriter, resp *http.Response, co
 		finalText = replaceCitationMarkersWithLinks(finalText, result.CitationLinks)
 	}
 	if shouldWriteUpstreamEmptyOutputError(finalText) {
-		status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
-		if historySession != nil {
-			historySession.error(status, message, code, finalThinking, finalText)
+		// Fallback: check if thinking content contains tool calls
+		if strings.Contains(finalThinking, "<tool_calls") {
+			detected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+			if len(detected.Calls) > 0 {
+				finalThinking = shared.cleanToolCallXML(finalThinking)
+			} else {
+				status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
+				if historySession != nil {
+					historySession.error(status, message, code, finalThinking, finalText)
+				}
+				writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
+				return
+			}
+		} else {
+			status, message, code := upstreamEmptyOutputDetail(result.ContentFilter, finalText, finalThinking)
+			if historySession != nil {
+				historySession.error(status, message, code, finalThinking, finalText)
+			}
+			writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
+			return
 		}
-		writeUpstreamEmptyOutputError(w, finalText, finalThinking, result.ContentFilter)
-		return
 	}
 	respBody := openaifmt.BuildChatCompletion(completionID, model, finalPrompt, finalThinking, finalText, toolNames)
 	finishReason := "stop"

--- a/internal/httpapi/openai/chat/handler_toolcall_test.go
+++ b/internal/httpapi/openai/chat/handler_toolcall_test.go
@@ -261,3 +261,85 @@ func TestHandleStreamEmitsDistinctToolCallIDsAcrossSeparateToolBlocks(t *testing
 		t.Fatalf("expected distinct tool call ids across blocks, got %#v body=%s", ids, rec.Body.String())
 	}
 }
+
+// TestHandleStreamDetectsToolCallInThinkingChannel tests that streaming path
+// detects tool calls when they appear inside thinking content (not text content).
+// This verifies the fix for the 429 empty output bug when thinking has tool calls.
+func TestHandleStreamDetectsToolCallInThinkingChannel(t *testing.T) {
+	h := &Handler{}
+	resp := makeSSEHTTPResponse(
+		`data: {"p":"response/thinking_content","v":"我需要调用 read_file 工具来读取文件\n<tool_calls>\n  <invoke name=\"read_file\">\n    <parameter name=\"path\">README.MD</parameter>\n  </invoke>\n</tool_calls>"}`,
+		`data: {"p":"response/content","v":""}`,
+		`data: [DONE]`,
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	h.handleStream(rec, req, resp, "cid-thinking-tc", "deepseek-v4-flash", "prompt", true, false, []string{"read_file"}, nil)
+
+	frames, done := parseSSEDataFrames(t, rec.Body.String())
+	if !done {
+		t.Fatalf("expected [DONE], body=%s", rec.Body.String())
+	}
+
+	reason := streamFinishReason(frames)
+	if reason != "tool_calls" {
+		t.Fatalf("expected finish_reason=tool_calls when thinking has tool calls, got %s body=%s", reason, rec.Body.String())
+	}
+	if !streamHasToolCallsDelta(frames) {
+		t.Fatalf("expected tool_calls delta when thinking has tool calls, body=%s", rec.Body.String())
+	}
+}
+
+// TestHandleNonStreamDetectsToolCallInThinkingChannel tests non-streaming path
+// for tool calls in thinking content instead of 429 empty output.
+func TestHandleNonStreamDetectsToolCallInThinkingChannel(t *testing.T) {
+	h := &Handler{}
+	resp := makeSSEHTTPResponse(
+		`data: {"p":"response/thinking_content","v":"工具调用出现在 thinking 中\n<tool_calls>\n  <invoke name=\"search\">\n    <parameter name=\"q\">golang</parameter>\n  </invoke>\n</tool_calls>"}`,
+		`data: [DONE]`,
+	)
+	rec := httptest.NewRecorder()
+
+	h.handleNonStream(rec, resp, "cid-ns-thinking", "deepseek-v4-flash", "prompt", true, false, []string{"search"}, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 when thinking contains tool calls, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	out := decodeJSONBody(t, rec.Body.String())
+	choices, _ := out["choices"].([]any)
+	if len(choices) == 0 {
+		t.Fatalf("expected at least one choice, got %#v", out)
+	}
+	choice := choices[0].(map[string]any)
+	msg, _ := choice["message"].(map[string]any)
+	if _, ok := msg["tool_calls"]; !ok {
+		t.Fatalf("expected tool_calls in message when thinking has <tool_calls>, got %#v", out)
+	}
+	reasoning, _ := msg["reasoning_content"].(string)
+	if strings.Contains(reasoning, "<tool_calls>") || strings.Contains(reasoning, "</tool_calls>") {
+		t.Fatalf("expected reasoning_content to be cleaned of <tool_calls> XML, got %q", reasoning)
+	}
+}
+
+// TestHandleStreamThinkingOnlyToolCallNo429 tests that streaming returns 200
+// when ALL content is thinking with tool calls (no text at all).
+func TestHandleStreamThinkingOnlyToolCallNo429(t *testing.T) {
+	h := &Handler{}
+	resp := makeSSEHTTPResponse(
+		`data: {"p":"response/thinking_content","v":"<tool_calls>\n  <invoke name=\"write_file\">\n    <parameter name=\"path\">output.txt</parameter>\n    <parameter name=\"content\">hello</parameter>\n  </invoke>\n</tool_calls>"}`,
+		`data: [DONE]`,
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	h.handleStream(rec, req, resp, "cid-thinking-only", "deepseek-v4-flash", "prompt", true, false, []string{"write_file"}, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 when thinking has tool calls, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	frames, _ := parseSSEDataFrames(t, rec.Body.String())
+	if streamFinishReason(frames) != "tool_calls" {
+		t.Fatalf("expected finish_reason=tool_calls when thinking has plain tool calls, got %v body=%s", streamFinishReason(frames), rec.Body.String())
+	}
+}

--- a/internal/httpapi/openai/chat/handler_toolcall_test.go
+++ b/internal/httpapi/openai/chat/handler_toolcall_test.go
@@ -291,6 +291,24 @@ func TestHandleStreamDetectsToolCallInThinkingChannel(t *testing.T) {
 	}
 }
 
+func TestHandleStreamThinkingToolCallDoesNotLeakXML(t *testing.T) {
+	h := &Handler{}
+	resp := makeSSEHTTPResponse(
+		`data: {"p":"response/thinking_content","v":"先读取文件\n<tool_calls>\n  "}`,
+		`data: {"p":"response/thinking_content","v":"<invoke name=\"read_file\">\n    <parameter name=\"path\">README.MD</parameter>\n  </invoke>\n</tool_calls>"}`,
+		`data: [DONE]`,
+	)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	h.handleStream(rec, req, resp, "cid-thinking-split", "deepseek-v4-flash", "prompt", true, false, []string{"read_file"}, nil)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<tool_calls>") || strings.Contains(body, "<invoke name=\"read_file\">") {
+		t.Fatalf("expected thinking tool XML to stay out of chat SSE body, got %s", body)
+	}
+}
+
 // TestHandleNonStreamDetectsToolCallInThinkingChannel tests non-streaming path
 // for tool calls in thinking content instead of 429 empty output.
 func TestHandleNonStreamDetectsToolCallInThinkingChannel(t *testing.T) {

--- a/internal/httpapi/openai/responses/responses_handler.go
+++ b/internal/httpapi/openai/responses/responses_handler.go
@@ -136,23 +136,13 @@ func (h *Handler) handleResponsesNonStream(w http.ResponseWriter, resp *http.Res
 	if searchEnabled {
 		sanitizedText = replaceCitationMarkersWithLinks(sanitizedText, result.CitationLinks)
 	}
-	// Fallback: if text has no tool calls, check thinking content for <tool_calls> XML
-	if writeUpstreamEmptyOutputError(w, sanitizedText, sanitizedThinking, result.ContentFilter) {
-		if strings.Contains(sanitizedThinking, "<tool_calls") {
-			detected := toolcall.ParseStandaloneToolCallsDetailed(sanitizedThinking, toolNames)
-			if len(detected.Calls) > 0 {
-				sanitizedThinking = shared.CleanToolCallXML(sanitizedThinking)
-			} else {
-				return
-			}
-		} else {
-			return
-		}
-	}
 	textParsed := toolcall.ParseStandaloneToolCallsDetailed(sanitizedText, toolNames)
 	logResponsesToolPolicyRejection(traceID, toolChoice, textParsed, "text")
-
-	callCount := len(textParsed.Calls)
+	detected, sanitizedThinking := shared.DetectToolCallsWithThinkingFallback(sanitizedText, sanitizedThinking, sanitizedThinking, toolNames)
+	if writeUpstreamEmptyOutputError(w, sanitizedText, sanitizedThinking, result.ContentFilter) && len(detected.Calls) == 0 {
+		return
+	}
+	callCount := len(detected.Calls)
 	if toolChoice.IsRequired() && callCount == 0 {
 		writeOpenAIErrorWithCode(w, http.StatusUnprocessableEntity, "tool_choice requires at least one valid tool call.", "tool_choice_violation")
 		return

--- a/internal/httpapi/openai/responses/responses_handler.go
+++ b/internal/httpapi/openai/responses/responses_handler.go
@@ -141,7 +141,7 @@ func (h *Handler) handleResponsesNonStream(w http.ResponseWriter, resp *http.Res
 		if strings.Contains(sanitizedThinking, "<tool_calls") {
 			detected := toolcall.ParseStandaloneToolCallsDetailed(sanitizedThinking, toolNames)
 			if len(detected.Calls) > 0 {
-				sanitizedThinking = shared.cleanToolCallXML(sanitizedThinking)
+				sanitizedThinking = shared.CleanToolCallXML(sanitizedThinking)
 			} else {
 				return
 			}

--- a/internal/httpapi/openai/responses/responses_handler.go
+++ b/internal/httpapi/openai/responses/responses_handler.go
@@ -15,6 +15,7 @@ import (
 	"ds2api/internal/config"
 	dsprotocol "ds2api/internal/deepseek/protocol"
 	openaifmt "ds2api/internal/format/openai"
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/promptcompat"
 	"ds2api/internal/sse"
 	streamengine "ds2api/internal/stream"
@@ -135,8 +136,18 @@ func (h *Handler) handleResponsesNonStream(w http.ResponseWriter, resp *http.Res
 	if searchEnabled {
 		sanitizedText = replaceCitationMarkersWithLinks(sanitizedText, result.CitationLinks)
 	}
+	// Fallback: if text has no tool calls, check thinking content for <tool_calls> XML
 	if writeUpstreamEmptyOutputError(w, sanitizedText, sanitizedThinking, result.ContentFilter) {
-		return
+		if strings.Contains(sanitizedThinking, "<tool_calls") {
+			detected := toolcall.ParseStandaloneToolCallsDetailed(sanitizedThinking, toolNames)
+			if len(detected.Calls) > 0 {
+				sanitizedThinking = shared.cleanToolCallXML(sanitizedThinking)
+			} else {
+				return
+			}
+		} else {
+			return
+		}
 	}
 	textParsed := toolcall.ParseStandaloneToolCallsDetailed(sanitizedText, toolNames)
 	logResponsesToolPolicyRejection(traceID, toolChoice, textParsed, "text")

--- a/internal/httpapi/openai/responses/responses_stream_runtime_core.go
+++ b/internal/httpapi/openai/responses/responses_stream_runtime_core.go
@@ -143,7 +143,7 @@ func (s *responsesStreamRuntime) finalize() {
 		thinkingParsed := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
 		if len(thinkingParsed.Calls) > 0 {
 			detected = thinkingParsed.Calls
-			finalThinking = shared.cleanToolCallXML(finalThinking)
+			finalThinking = shared.CleanToolCallXML(finalThinking)
 		}
 	}
 

--- a/internal/httpapi/openai/responses/responses_stream_runtime_core.go
+++ b/internal/httpapi/openai/responses/responses_stream_runtime_core.go
@@ -7,6 +7,7 @@ import (
 
 	"ds2api/internal/config"
 	openaifmt "ds2api/internal/format/openai"
+	"ds2api/internal/httpapi/openai/shared"
 	"ds2api/internal/promptcompat"
 	"ds2api/internal/sse"
 	streamengine "ds2api/internal/stream"
@@ -136,6 +137,15 @@ func (s *responsesStreamRuntime) finalize() {
 	textParsed := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
 	detected := textParsed.Calls
 	s.logToolPolicyRejections(textParsed)
+
+	// Fallback: if text has no tool calls, check thinking content.
+	if len(detected) == 0 && strings.Contains(finalThinking, "<tool_calls") {
+		thinkingParsed := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
+		if len(thinkingParsed.Calls) > 0 {
+			detected = thinkingParsed.Calls
+			finalThinking = shared.cleanToolCallXML(finalThinking)
+		}
+	}
 
 	if len(detected) > 0 {
 		s.toolCallsEmitted = true

--- a/internal/httpapi/openai/responses/responses_stream_runtime_core.go
+++ b/internal/httpapi/openai/responses/responses_stream_runtime_core.go
@@ -36,7 +36,9 @@ type responsesStreamRuntime struct {
 	toolCallsDoneEmitted bool
 
 	sieve             toolstream.State
-	thinking          strings.Builder
+	thinkingSieve     toolstream.State
+	thinkingRaw       strings.Builder
+	thinkingVisible   strings.Builder
 	text              strings.Builder
 	visibleText       strings.Builder
 	streamToolCallIDs map[int]string
@@ -127,7 +129,9 @@ func (s *responsesStreamRuntime) failResponse(status int, message, code string) 
 }
 
 func (s *responsesStreamRuntime) finalize() {
-	finalThinking := s.thinking.String()
+	s.flushThinking()
+	finalThinkingRaw := s.thinkingRaw.String()
+	finalThinking := s.thinkingVisible.String()
 	finalText := cleanVisibleOutput(s.text.String(), s.stripReferenceMarkers)
 
 	if s.bufferToolContent {
@@ -135,17 +139,9 @@ func (s *responsesStreamRuntime) finalize() {
 	}
 
 	textParsed := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
-	detected := textParsed.Calls
 	s.logToolPolicyRejections(textParsed)
-
-	// Fallback: if text has no tool calls, check thinking content.
-	if len(detected) == 0 && strings.Contains(finalThinking, "<tool_calls") {
-		thinkingParsed := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
-		if len(thinkingParsed.Calls) > 0 {
-			detected = thinkingParsed.Calls
-			finalThinking = shared.CleanToolCallXML(finalThinking)
-		}
-	}
+	detectedResult, finalThinking := shared.DetectToolCallsWithThinkingFallback(finalText, finalThinkingRaw, finalThinking, s.toolNames)
+	detected := detectedResult.Calls
 
 	if len(detected) > 0 {
 		s.toolCallsEmitted = true
@@ -211,15 +207,21 @@ func (s *responsesStreamRuntime) onParsed(parsed sse.LineResult) streamengine.Pa
 		}
 		contentSeen = true
 		if p.Type == "thinking" {
-			if !s.thinkingEnabled {
-				continue
-			}
-			trimmed := sse.TrimContinuationOverlap(s.thinking.String(), cleanedText)
+			trimmed := sse.TrimContinuationOverlap(s.thinkingRaw.String(), cleanedText)
 			if trimmed == "" {
 				continue
 			}
-			s.thinking.WriteString(trimmed)
-			s.sendEvent("response.reasoning.delta", openaifmt.BuildResponsesReasoningDeltaPayload(s.responseID, trimmed))
+			s.thinkingRaw.WriteString(trimmed)
+			if !s.thinkingEnabled {
+				continue
+			}
+			for _, evt := range toolstream.ProcessChunk(&s.thinkingSieve, trimmed, s.toolNames) {
+				if evt.Content == "" {
+					continue
+				}
+				s.thinkingVisible.WriteString(evt.Content)
+				s.sendEvent("response.reasoning.delta", openaifmt.BuildResponsesReasoningDeltaPayload(s.responseID, evt.Content))
+			}
 			continue
 		}
 
@@ -236,4 +238,17 @@ func (s *responsesStreamRuntime) onParsed(parsed sse.LineResult) streamengine.Pa
 	}
 
 	return streamengine.ParsedDecision{ContentSeen: contentSeen}
+}
+
+func (s *responsesStreamRuntime) flushThinking() {
+	if !s.thinkingEnabled {
+		return
+	}
+	for _, evt := range toolstream.Flush(&s.thinkingSieve, s.toolNames) {
+		if evt.Content == "" {
+			continue
+		}
+		s.thinkingVisible.WriteString(evt.Content)
+		s.sendEvent("response.reasoning.delta", openaifmt.BuildResponsesReasoningDeltaPayload(s.responseID, evt.Content))
+	}
 }

--- a/internal/httpapi/openai/responses/responses_stream_test.go
+++ b/internal/httpapi/openai/responses/responses_stream_test.go
@@ -232,6 +232,41 @@ func TestHandleResponsesStreamFailsWhenUpstreamHasOnlyThinking(t *testing.T) {
 	}
 }
 
+func TestHandleResponsesStreamDetectsThinkingToolCallWithoutLeakingXML(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	rec := httptest.NewRecorder()
+
+	sseLine := func(path, value string) string {
+		b, _ := json.Marshal(map[string]any{
+			"p": path,
+			"v": value,
+		})
+		return "data: " + string(b) + "\n"
+	}
+
+	streamBody := sseLine("response/thinking_content", "先读取文件\n<tool_calls>\n  ") +
+		sseLine("response/thinking_content", "<invoke name=\"read_file\">\n    <parameter name=\"path\">README.MD</parameter>\n  </invoke>\n</tool_calls>") +
+		"data: [DONE]\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(streamBody)),
+	}
+
+	h.handleResponsesStream(rec, req, resp, "owner-a", "resp_test", "deepseek-v4-pro", "prompt", true, false, []string{"read_file"}, promptcompat.DefaultToolChoicePolicy(), "")
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<tool_calls>") || strings.Contains(body, "<invoke name=\"read_file\">") {
+		t.Fatalf("expected thinking tool XML to stay out of SSE body, got %s", body)
+	}
+	if !strings.Contains(body, "event: response.function_call_arguments.done") {
+		t.Fatalf("expected function call completion event, body=%s", body)
+	}
+	if strings.Contains(body, "event: response.failed") {
+		t.Fatalf("did not expect response.failed, body=%s", body)
+	}
+}
+
 func TestHandleResponsesNonStreamRequiredToolChoiceViolation(t *testing.T) {
 	h := &Handler{}
 	rec := httptest.NewRecorder()
@@ -255,6 +290,54 @@ func TestHandleResponsesNonStreamRequiredToolChoiceViolation(t *testing.T) {
 	errObj, _ := out["error"].(map[string]any)
 	if asString(errObj["code"]) != "tool_choice_violation" {
 		t.Fatalf("expected code=tool_choice_violation, got %#v", out)
+	}
+}
+
+func TestHandleResponsesNonStreamDetectsToolCallInThinkingChannel(t *testing.T) {
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(
+			`data: {"p":"response/thinking_content","v":"先读取文件\n<tool_calls>\n  <invoke name=\"read_file\">\n    <parameter name=\"path\">README.MD</parameter>\n  </invoke>\n</tool_calls>"}` + "\n" +
+				`data: [DONE]` + "\n",
+		)),
+	}
+
+	h.handleResponsesNonStream(rec, resp, "owner-a", "resp_test", "deepseek-v4-flash", "prompt", true, false, []string{"read_file"}, promptcompat.DefaultToolChoicePolicy(), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 when thinking contains tool calls, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	out := decodeJSONBody(t, rec.Body.String())
+	output, _ := out["output"].([]any)
+	if len(output) == 0 {
+		t.Fatalf("expected output items, got %#v", out)
+	}
+	first, _ := output[0].(map[string]any)
+	if asString(first["type"]) != "function_call" {
+		t.Fatalf("expected function_call output item, got %#v", first)
+	}
+}
+
+func TestHandleResponsesNonStreamRequiredToolChoiceAcceptsThinkingToolCall(t *testing.T) {
+	h := &Handler{}
+	rec := httptest.NewRecorder()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(
+			`data: {"p":"response/thinking_content","v":"<tool_calls>\n  <invoke name=\"read_file\">\n    <parameter name=\"path\">README.MD</parameter>\n  </invoke>\n</tool_calls>"}` + "\n" +
+				`data: [DONE]` + "\n",
+		)),
+	}
+	policy := promptcompat.ToolChoicePolicy{
+		Mode:    promptcompat.ToolChoiceRequired,
+		Allowed: map[string]struct{}{"read_file": {}},
+	}
+
+	h.handleResponsesNonStream(rec, resp, "owner-a", "resp_test", "deepseek-v4-flash", "prompt", true, false, []string{"read_file"}, policy, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 when required tool_choice is satisfied by thinking tool call, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/httpapi/openai/shared/leaked_output_sanitize.go
+++ b/internal/httpapi/openai/shared/leaked_output_sanitize.go
@@ -59,7 +59,6 @@ func sanitizeLeakedOutput(text string) string {
 	out = leakedThinkTagPattern.ReplaceAllString(out, "")
 	out = leakedBOSMarkerPattern.ReplaceAllString(out, "")
 	out = leakedMetaMarkerPattern.ReplaceAllString(out, "")
-	out = CleanToolCallXML(out)
 	out = sanitizeLeakedAgentXMLBlocks(out)
 	return out
 }

--- a/internal/httpapi/openai/shared/leaked_output_sanitize.go
+++ b/internal/httpapi/openai/shared/leaked_output_sanitize.go
@@ -41,10 +41,10 @@ var leakedAgentResultTagPattern = regexp.MustCompile(`(?is)</?result>`)
 // that raw XML is stripped from reasoning_content before it reaches the client.
 var leakedToolCallXMLPattern = regexp.MustCompile(`(?is)<tool_calls>.*?</tool_calls>`)
 
-// cleanToolCallXML removes <tool_calls>...</tool_calls> blocks from the given text.
+// CleanToolCallXML removes <tool_calls>...</tool_calls> blocks from the given text.
 // This should only be called AFTER tool calls have been detected and extracted,
 // to prevent the raw XML from leaking into reasoning_content exposed to the client.
-func cleanToolCallXML(text string) string {
+func CleanToolCallXML(text string) string {
 	return leakedToolCallXMLPattern.ReplaceAllString(text, "")
 }
 
@@ -59,7 +59,7 @@ func sanitizeLeakedOutput(text string) string {
 	out = leakedThinkTagPattern.ReplaceAllString(out, "")
 	out = leakedBOSMarkerPattern.ReplaceAllString(out, "")
 	out = leakedMetaMarkerPattern.ReplaceAllString(out, "")
-	out = cleanToolCallXML(out)
+	out = CleanToolCallXML(out)
 	out = sanitizeLeakedAgentXMLBlocks(out)
 	return out
 }

--- a/internal/httpapi/openai/shared/leaked_output_sanitize.go
+++ b/internal/httpapi/openai/shared/leaked_output_sanitize.go
@@ -36,6 +36,18 @@ var leakedAgentWrapperPlusResultOpenPattern = regexp.MustCompile(`(?is)<(?:attem
 var leakedAgentResultPlusWrapperClosePattern = regexp.MustCompile(`(?is)</result>\s*</(?:attempt_completion|ask_followup_question|new_task)\b[^>]*>`)
 var leakedAgentResultTagPattern = regexp.MustCompile(`(?is)</?result>`)
 
+// leakedToolCallXMLPattern matches complete <tool_calls>...</tool_calls> blocks including
+// nested <invoke>, <parameter>, and CDATA sections. Applied after tool-call detection so
+// that raw XML is stripped from reasoning_content before it reaches the client.
+var leakedToolCallXMLPattern = regexp.MustCompile(`(?is)<tool_calls>.*?</tool_calls>`)
+
+// cleanToolCallXML removes <tool_calls>...</tool_calls> blocks from the given text.
+// This should only be called AFTER tool calls have been detected and extracted,
+// to prevent the raw XML from leaking into reasoning_content exposed to the client.
+func cleanToolCallXML(text string) string {
+	return leakedToolCallXMLPattern.ReplaceAllString(text, "")
+}
+
 func sanitizeLeakedOutput(text string) string {
 	if text == "" {
 		return text
@@ -47,6 +59,7 @@ func sanitizeLeakedOutput(text string) string {
 	out = leakedThinkTagPattern.ReplaceAllString(out, "")
 	out = leakedBOSMarkerPattern.ReplaceAllString(out, "")
 	out = leakedMetaMarkerPattern.ReplaceAllString(out, "")
+	out = cleanToolCallXML(out)
 	out = sanitizeLeakedAgentXMLBlocks(out)
 	return out
 }

--- a/internal/httpapi/openai/shared/toolcall_detect.go
+++ b/internal/httpapi/openai/shared/toolcall_detect.go
@@ -1,0 +1,26 @@
+package shared
+
+import (
+	"strings"
+
+	"ds2api/internal/toolcall"
+)
+
+// DetectToolCallsWithThinkingFallback checks visible text first, then falls back
+// to the thinking channel source when the model emitted canonical tool XML there.
+// thinkingSource is used only for detection; thinkingExposed is what may be sent
+// back to the client and will be cleaned only after a valid tool call is found.
+func DetectToolCallsWithThinkingFallback(finalText, thinkingSource, thinkingExposed string, toolNames []string) (toolcall.ToolCallParseResult, string) {
+	detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
+	if len(detected.Calls) > 0 {
+		return detected, thinkingExposed
+	}
+	if !strings.Contains(thinkingSource, "<tool_calls") {
+		return detected, thinkingExposed
+	}
+	thinkingDetected := toolcall.ParseStandaloneToolCallsDetailed(thinkingSource, toolNames)
+	if len(thinkingDetected.Calls) == 0 {
+		return detected, thinkingExposed
+	}
+	return thinkingDetected, CleanToolCallXML(thinkingExposed)
+}

--- a/plans/fix-toolcall-in-thinking.md
+++ b/plans/fix-toolcall-in-thinking.md
@@ -1,0 +1,128 @@
+# 修复: 模型思维链中出现工具调用时报错
+
+## 上下文
+
+DeepSeek 模型推理时可能将 `<tool_calls>` XML 发送在 SSE 的 **THINK 片段**中（而非 RESPONSE 片段）。当前代码仅在 **text 内容**中检测工具调用，忽略 thinking，导致：
+
+| 场景 | 表现 | 影响 |
+|------|------|------|
+| 流式 + 全部在 thinking | `finalize()` 触发 "empty output" 429 错误 | **致命 — 必报错** |
+| 流式 + 部分在 text | 工具调用漏检，`reasoning_content` 泄露 XML | 功能缺失 |
+| 非流式 | 工具调用静默丢失，`reasoning_content` 泄露 XML | 功能缺失 |
+
+**受影响路径**：
+- `/v1/chat/completions` (stream & non-stream)
+- `/v1/responses` (stream & non-stream) — **同样存在**
+
+## 根因（已由 Codex 审核确认）
+
+| # | 文件 | 行号 | 问题 |
+|---|------|------|------|
+| 1 | `sse/parser.go` | 71-107, 280-325 | `ParseSSEChunkForContent()` 只按 path/type 分 thinking/text；`splitThinkingParts()` 只识别 `</think>` |
+| 2 | `chat_stream_runtime.go` | 136 | `finalize()` 仅对 `s.text` 做工具调用解析 |
+| 3 | `chat_stream_runtime.go` | 255-263 | `onParsed()` 中 thinking 不走 tool sieve |
+| 4 | `render_chat.go` | 10 | `BuildChatCompletion()` 仅对 `finalText` 解析 |
+| 5 | `handler_chat.go` | 165 | `shouldWriteUpstreamEmptyOutputError(finalText)` |
+| 6 | `chat_stream_runtime.go` | 204 | `finalize()` 中 `finalText == ""` 门禁 |
+| 7 | `responses_handler.go` | 124 | `/v1/responses` 同样问题 |
+| 8 | `responses_stream_runtime_core.go` | 128 | `/v1/responses` stream 同样问题 |
+| 9 | `render_responses.go` | 12 | `/v1/responses` non-stream 同样问题 |
+| 10 | `leaked_output_sanitize.go` | 39-52 | 未清理 `<tool_calls>` XML |
+
+## 修复方案
+
+### 第一阶段：核心修复（chat + responses 平行修复）
+
+#### 1. `chat_stream_runtime.go:131-220` — finalize() 流式路径修复
+```go
+// 第 136 行后：fallback 检测 thinking 中的工具调用
+detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, s.toolNames)
+if len(detected.Calls) == 0 {
+    detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, s.toolNames)
+    if len(detected.Calls) > 0 {
+        // 清理 thinking 中的 XML，防止泄露
+        finalThinking = cleanToolCallXML(finalThinking)
+        s.finalThinking = finalThinking
+    }
+}
+```
+- 修改第 204 行空输出检查：加上 `len(detected.Calls) == 0` 的条件
+- 找到工具调用后正常走第 137-154 行 emit 逻辑
+
+#### 2. `handler_chat.go:165` — handleNonStream() 非流式修复
+```go
+// 第 165 行之前增加
+if shouldWriteUpstreamEmptyOutputError(finalText) {
+    // fallback: 检查 thinking 中是否有工具调用
+    detected := toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+    if len(detected.Calls) > 0 {
+        // 不报空输出错误，让 BuildChatCompletion 处理
+    } else {
+        // 原逻辑 — 报 429
+    }
+}
+```
+
+#### 3. `render_chat.go:9-30` — BuildChatCompletion() 增加 thinking fallback
+```go
+detected := toolcall.ParseStandaloneToolCallsDetailed(finalText, toolNames)
+if len(detected.Calls) == 0 {
+    detected = toolcall.ParseStandaloneToolCallsDetailed(finalThinking, toolNames)
+    if len(detected.Calls) > 0 {
+        finalThinking = cleanToolCallXML(finalThinking)
+    }
+}
+```
+
+#### 4. `chat_stream_runtime.go:255-263` — onParsed() 流式 thinking 过滤
+```go
+// 发送 reasoning_content delta 前检测并过滤工具调用 XML
+// 如果 cleanedText 包含 <tool_calls>，送入 toolstream 或跳过
+// 不发送裸 XML 给客户端
+```
+
+#### 5. `leaked_output_sanitize.go:39-52` — 增加工具调用 XML 清理
+```go
+var leakedToolCallXMLPattern = regexp.MustCompile(`(?is)<tool_calls>.*?</tool_calls>`)
+// 在 sanitizeLeakedOutput() 中调用（需在工具调用检测之后）
+```
+
+#### 6. `/v1/responses` 路径同步修复
+- `responses_handler.go:124` — `handleNonStreamResponses()`
+- `responses_stream_runtime_core.go:128` — `finalizeResponses()`
+- `render_responses.go:12` — `BuildResponseObject()`
+
+### 第二阶段：回归测试
+
+#### 7. `handler_toolcall_test.go` — 新增测试用例
+- `response/thinking_content` 含 `<tool_calls>` XML → 断言 `finish_reason="tool_calls"`，不再 429
+- `response/thinking_content` 混合文本 + `<tool_calls>` → 断言正确解析
+- 确保 `reasoning_content` 不含裸 XML
+
+## 修改文件清单
+
+| 文件 | 修改类型 |
+|------|----------|
+| `internal/httpapi/openai/chat/chat_stream_runtime.go` | 核心修改 |
+| `internal/httpapi/openai/chat/handler_chat.go` | 核心修改 |
+| `internal/format/openai/render_chat.go` | 核心修改 |
+| `internal/httpapi/openai/shared/leaked_output_sanitize.go` | 防泄漏补充 |
+| `internal/httpapi/openai/responses/handler.go` | 对称修复 |
+| `internal/httpapi/openai/responses/responses_stream_runtime_core.go` | 对称修复 |
+| `internal/format/openai/render_responses.go` | 对称修复 |
+| `internal/httpapi/openai/chat/handler_toolcall_test.go` | 回归测试 |
+
+## 验证方法
+
+```bash
+# 1. 编译验证
+cd D:\Source\ds2api && go build ./...
+
+# 2. 运行现有测试
+go test ./internal/httpapi/openai/chat/...
+
+# 3. 手动测试（用 raw_capture 或 curl）
+# 构造 thinking 含 <tool_calls> 的 SSE 流，验证不再 429
+
+# 4. 检查 reasoning_content 不含 XML
+```

--- a/plans/fix-toolcall-in-thinking.md
+++ b/plans/fix-toolcall-in-thinking.md
@@ -81,10 +81,10 @@ if len(detected.Calls) == 0 {
 // 不发送裸 XML 给客户端
 ```
 
-#### 5. `leaked_output_sanitize.go:39-52` — 增加工具调用 XML 清理
+#### 5. `shared/CleanToolCallXML` + 流式 thinking sieve — 定向清理而不是全局清理
 ```go
 var leakedToolCallXMLPattern = regexp.MustCompile(`(?is)<tool_calls>.*?</tool_calls>`)
-// 在 sanitizeLeakedOutput() 中调用（需在工具调用检测之后）
+// 只在成功检测并提取工具调用后，对最终 exposed thinking 做清理
 ```
 
 #### 6. `/v1/responses` 路径同步修复
@@ -106,7 +106,7 @@ var leakedToolCallXMLPattern = regexp.MustCompile(`(?is)<tool_calls>.*?</tool_ca
 | `internal/httpapi/openai/chat/chat_stream_runtime.go` | 核心修改 |
 | `internal/httpapi/openai/chat/handler_chat.go` | 核心修改 |
 | `internal/format/openai/render_chat.go` | 核心修改 |
-| `internal/httpapi/openai/shared/leaked_output_sanitize.go` | 防泄漏补充 |
+| `internal/httpapi/openai/shared/leaked_output_sanitize.go` | 定向清理补充 |
 | `internal/httpapi/openai/responses/handler.go` | 对称修复 |
 | `internal/httpapi/openai/responses/responses_stream_runtime_core.go` | 对称修复 |
 | `internal/format/openai/render_responses.go` | 对称修复 |


### PR DESCRIPTION
## 概要

修复思维链阶段调用工具时的两类问题：
1. 原始 `<tool_calls>` / `<invoke>` 可能泄漏到可见输出。
2. `tool_choice=require` 和空输出判断没有正确覆盖 thinking 通道。

## 主要修改

- 将 tool call 检测收敛到共享逻辑，先保留 raw thinking 用于识别，再生成可见 thinking。
- 不再在通用清理链路里提前删除 `<tool_calls>`，避免检测前被误清理。
- chat / responses 的非流式和流式路径统一按 thinking fallback 检测 tool call。
- `tool_choice=require` 现在会正确接受 thinking 中的 canonical tool call。
- 流式路径对 reasoning delta 先经过 sieve，再发给客户端，避免原始 XML 分块泄漏。
- 补充了回归测试，覆盖 chat / responses 的 thinking-only tool call、required tool_choice、以及流式分块不泄漏。

## 验证

- 本地真实请求验证通过：
  - `GET /healthz`
  - `GET /v1/models`
  - `POST /v1/chat/completions` 非流式 tool-call
  - `POST /v1/chat/completions` 流式 tool-call
  - `POST /v1/responses` 非流式 `tool_choice=required`
  - `POST /v1/responses` 流式 tool-call
  - `GET /admin/version`
- 结果确认：
  - tool call 能正常返回
  - 未发现原始 `<tool_calls>` 泄漏到流式输出
  - `tool_choice=require` 在 thinking tool call 场景下正常工作

Fixes #327
