### PR TITLE
支持 reference 引用标签转链接，并兼容 0 基序号映射

### DIFF
--- a/internal/httpapi/openai/citation_links_test.go
+++ b/internal/httpapi/openai/citation_links_test.go
@@ -26,3 +26,31 @@ func TestReplaceCitationMarkersWithLinksKeepsUnknownIndex(t *testing.T) {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
+
+func TestReplaceCitationMarkersWithLinksSupportsReferenceMarker(t *testing.T) {
+	raw := "新闻摘要[reference:1]，详情[reference:2]。"
+	links := map[int]string{
+		1: "https://example.com/r1",
+		2: "https://example.com/r2",
+	}
+
+	got := replaceCitationMarkersWithLinks(raw, links)
+	want := "新闻摘要[1](https://example.com/r1)，详情[2](https://example.com/r2)。"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestReplaceCitationMarkersWithLinksSupportsReferenceZeroBased(t *testing.T) {
+	raw := "来源[reference:0] 与 [reference:1]。"
+	links := map[int]string{
+		1: "https://example.com/first",
+		2: "https://example.com/second",
+	}
+
+	got := replaceCitationMarkersWithLinks(raw, links)
+	want := "来源[0](https://example.com/first) 与 [1](https://example.com/second)。"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/internal/httpapi/openai/shared/citation_links.go
+++ b/internal/httpapi/openai/shared/citation_links.go
@@ -7,22 +7,27 @@ import (
 	"strings"
 )
 
-var citationMarkerPattern = regexp.MustCompile(`(?i)\[citation:\s*(\d+)\]`)
+var citationMarkerPattern = regexp.MustCompile(`(?i)\[(citation|reference):\s*(\d+)\]`)
 
 func ReplaceCitationMarkersWithLinks(text string, links map[int]string) string {
 	if strings.TrimSpace(text) == "" || len(links) == 0 {
 		return text
 	}
+	zeroBased := strings.Contains(strings.ToLower(text), "[reference:0]")
 	return citationMarkerPattern.ReplaceAllStringFunc(text, func(match string) string {
 		sub := citationMarkerPattern.FindStringSubmatch(match)
-		if len(sub) < 2 {
+		if len(sub) < 3 {
 			return match
 		}
-		idx, err := strconv.Atoi(strings.TrimSpace(sub[1]))
-		if err != nil || idx <= 0 {
+		idx, err := strconv.Atoi(strings.TrimSpace(sub[2]))
+		if err != nil || idx < 0 {
 			return match
 		}
-		url := strings.TrimSpace(links[idx])
+		lookupIdx := idx
+		if zeroBased {
+			lookupIdx = idx + 1
+		}
+		url := strings.TrimSpace(links[lookupIdx])
 		if url == "" {
 			return match
 		}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [✅ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

背景
通过 API 返回的正文里出现 [reference:N] 标签，但旧逻辑只会替换 [citation:N]，导致 reference 标签未被转成链接。

改动

正则由仅匹配 citation 扩展为同时匹配 citation 与 reference
引入 reference:0 场景下的序号偏移处理，保证链接映射正确
增加单元测试：
[reference:N] 标签替换
[reference:0] 的 0 基序号映射
保持原有未知索引不替换行为
验证

go test httpapi. 全部通过
本地接口验证，[reference:N] 标签可被替换为可点击链接
影响范围

仅影响 OpenAI 输出中的引用标签替换逻辑
不改变上游请求协议，不影响非引用文本内容