### PR TITLE
Verify GHCR latest tag matches release and show version source/latest in dashboard

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -126,6 +126,32 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+
+      - name: Verify GHCR latest tag points to current release
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository }}"
+          TAG_REF="${IMAGE}:${RELEASE_TAG}"
+          LATEST_REF="${IMAGE}:latest"
+
+          # GHCR tag updates can be eventually consistent right after multi-arch push.
+          # Retry for a short window to avoid false negatives caused by propagation delay.
+          for i in {1..12}; do
+            TAG_DIGEST="$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' "${TAG_REF}" 2>/dev/null | tr -d '"' || true)"
+            LATEST_DIGEST="$(docker buildx imagetools inspect --format '{{json .Manifest.Digest}}' "${LATEST_REF}" 2>/dev/null | tr -d '"' || true)"
+
+            if [ -n "${TAG_DIGEST}" ] && [ -n "${LATEST_DIGEST}" ] && [ "${TAG_DIGEST}" = "${LATEST_DIGEST}" ]; then
+              echo "Verified ${LATEST_REF} -> ${RELEASE_TAG} (${TAG_DIGEST})."
+              exit 0
+            fi
+
+            echo "Waiting for GHCR tag propagation (${i}/12): ${TAG_REF}=${TAG_DIGEST:-<empty>} ${LATEST_REF}=${LATEST_DIGEST:-<empty>}" >&2
+            sleep 10
+          done
+
+          echo "Digest mismatch after retries: ${TAG_REF}=${TAG_DIGEST:-<empty>}, ${LATEST_REF}=${LATEST_DIGEST:-<empty>}" >&2
+          exit 1
+
       - name: Export Docker image archives for release assets
         run: |
           set -euo pipefail

--- a/webui/src/layout/DashboardShell.jsx
+++ b/webui/src/layout/DashboardShell.jsx
@@ -201,6 +201,12 @@ export default function DashboardShell({ token, onLogout, config, fetchConfig, s
                         <div className="bg-background rounded-lg p-3 border border-border shadow-sm">
                             <div className="text-[9px] text-muted-foreground font-bold uppercase tracking-wider mb-1 opacity-70">{t('sidebar.version')}</div>
                             <div className="text-xs font-semibold text-foreground">{versionInfo?.current_tag || '-'}</div>
+                            {versionInfo?.source && (
+                                <div className="text-[10px] text-muted-foreground mt-0.5">source: {versionInfo.source}</div>
+                            )}
+                            {versionInfo?.latest_tag && (
+                                <div className="text-[10px] text-muted-foreground">latest release: {versionInfo.latest_tag}</div>
+                            )}
                             {versionInfo?.has_update && (
                                 <a
                                     className="inline-flex mt-1 text-[10px] text-amber-500 hover:text-amber-400"


### PR DESCRIPTION
### Motivation
- Prevent release races where GHCR `latest` does not yet point to the newly pushed multi-arch image by verifying manifests after push.
- Make version metadata more informative in the UI by exposing the release `source` and `latest_tag` in the dashboard version panel.

### Description
- Add a `Verify GHCR latest tag points to current release` step to `.github/workflows/release-artifacts.yml` that uses `docker buildx imagetools inspect` to compare manifest digests for `ghcr.io/${{ github.repository }}:${RELEASE_TAG}` and `ghcr.io/${{ github.repository }}:latest` with a retry loop (12 attempts, 10s sleep) and fails the job on mismatch.
- The workflow step sets `set -euo pipefail`, captures digests into `TAG_DIGEST` and `LATEST_DIGEST`, logs propagation progress, and exits non-zero if digests do not match after retries.
- Update `webui/src/layout/DashboardShell.jsx` to conditionally render `versionInfo.source` as `source: ...` and `versionInfo.latest_tag` as `latest release: ...` alongside the existing version and update link.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f193f389c8833396345ed59fba3ff0)