### PR TITLE
fix(sse): batch tiny stream chunks before emitting

### DIFF
--- a/internal/sse/stream.go
+++ b/internal/sse/stream.go
@@ -4,12 +4,15 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"time"
 )
 
 const (
 	parsedLineBufferSize = 128
 	scannerBufferSize    = 64 * 1024
 	maxScannerLineSize   = 2 * 1024 * 1024
+	minFlushChars        = 160
+	maxFlushWait         = 80 * time.Millisecond
 )
 
 // StartParsedLinePump scans an upstream DeepSeek SSE body and emits normalized
@@ -20,21 +23,109 @@ func StartParsedLinePump(ctx context.Context, body io.Reader, thinkingEnabled bo
 	done := make(chan error, 1)
 	go func() {
 		defer close(out)
-		scanner := bufio.NewScanner(body)
-		scanner.Buffer(make([]byte, 0, scannerBufferSize), maxScannerLineSize)
+		type scanItem struct {
+			line []byte
+			err  error
+			eof  bool
+		}
+		lineCh := make(chan scanItem, 1)
+		go func() {
+			scanner := bufio.NewScanner(body)
+			scanner.Buffer(make([]byte, 0, scannerBufferSize), maxScannerLineSize)
+			for scanner.Scan() {
+				line := append([]byte{}, scanner.Bytes()...)
+				lineCh <- scanItem{line: line}
+			}
+			lineCh <- scanItem{err: scanner.Err(), eof: true}
+			close(lineCh)
+		}()
+
+		ticker := time.NewTicker(maxFlushWait)
+		defer ticker.Stop()
 		currentType := initialType
-		for scanner.Scan() {
-			line := append([]byte{}, scanner.Bytes()...)
-			result := ParseDeepSeekContentLine(line, thinkingEnabled, currentType)
-			currentType = result.NextType
+		var pending *LineResult
+		pendingChars := 0
+
+		sendResult := func(r LineResult) bool {
 			select {
-			case out <- result:
+			case out <- r:
+				return true
+			case <-ctx.Done():
+				done <- ctx.Err()
+				return false
+			}
+		}
+
+		flushPending := func() bool {
+			if pending == nil {
+				return true
+			}
+			if !sendResult(*pending) {
+				return false
+			}
+			pending = nil
+			pendingChars = 0
+			return true
+		}
+
+		for {
+			select {
 			case <-ctx.Done():
 				done <- ctx.Err()
 				return
+			case <-ticker.C:
+				if !flushPending() {
+					return
+				}
+			case item, ok := <-lineCh:
+				if !ok || item.eof {
+					if !flushPending() {
+						return
+					}
+					done <- item.err
+					return
+				}
+				line := item.line
+				result := ParseDeepSeekContentLine(line, thinkingEnabled, currentType)
+				currentType = result.NextType
+
+				canAccumulate := result.Parsed && !result.Stop && result.ErrorMessage == "" && !result.ContentFilter && result.ResponseMessageID == 0
+				if canAccumulate {
+					lineChars := 0
+					for _, p := range result.Parts {
+						lineChars += len(p.Text)
+					}
+					for _, p := range result.ToolDetectionThinkingParts {
+						lineChars += len(p.Text)
+					}
+					if lineChars > 0 {
+						if pending == nil {
+							cp := result
+							pending = &cp
+						} else {
+							pending.Parts = append(pending.Parts, result.Parts...)
+							pending.ToolDetectionThinkingParts = append(pending.ToolDetectionThinkingParts, result.ToolDetectionThinkingParts...)
+							pending.NextType = result.NextType
+						}
+						pendingChars += lineChars
+						if pendingChars < minFlushChars {
+							continue
+						}
+						if !flushPending() {
+							return
+						}
+						continue
+					}
+				}
+
+				if !flushPending() {
+					return
+				}
+				if !sendResult(result) {
+					return
+				}
 			}
 		}
-		done <- scanner.Err()
 	}()
 	return out, done
 }

--- a/internal/sse/stream.go
+++ b/internal/sse/stream.go
@@ -29,15 +29,29 @@ func StartParsedLinePump(ctx context.Context, body io.Reader, thinkingEnabled bo
 			eof  bool
 		}
 		lineCh := make(chan scanItem, 1)
+		stopScanner := make(chan struct{})
+		defer close(stopScanner)
 		go func() {
+			sendScanItem := func(item scanItem) bool {
+				select {
+				case lineCh <- item:
+					return true
+				case <-ctx.Done():
+					return false
+				case <-stopScanner:
+					return false
+				}
+			}
+			defer close(lineCh)
 			scanner := bufio.NewScanner(body)
 			scanner.Buffer(make([]byte, 0, scannerBufferSize), maxScannerLineSize)
 			for scanner.Scan() {
 				line := append([]byte{}, scanner.Bytes()...)
-				lineCh <- scanItem{line: line}
+				if !sendScanItem(scanItem{line: line}) {
+					return
+				}
 			}
-			lineCh <- scanItem{err: scanner.Err(), eof: true}
-			close(lineCh)
+			_ = sendScanItem(scanItem{err: scanner.Err(), eof: true})
 		}()
 
 		ticker := time.NewTicker(maxFlushWait)

--- a/internal/sse/stream_edge_test.go
+++ b/internal/sse/stream_edge_test.go
@@ -38,8 +38,8 @@ func TestStartParsedLinePumpMultipleLines(t *testing.T) {
 	if err := <-done; err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(collected) < 3 {
-		t.Fatalf("expected at least 3 results, got %d", len(collected))
+	if len(collected) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(collected))
 	}
 	// First should be thinking
 	if collected[0].Parts[0].Type != "thinking" {
@@ -173,5 +173,33 @@ func TestStartParsedLinePumpThinkingDisabled(t *testing.T) {
 
 	if len(parts) < 1 {
 		t.Fatalf("expected at least 1 part, got %d", len(parts))
+	}
+}
+
+func TestStartParsedLinePumpAccumulatesSmallChunks(t *testing.T) {
+	body := strings.NewReader(
+		"data: {\"p\":\"response/content\",\"v\":\"h\"}\n" +
+			"data: {\"p\":\"response/content\",\"v\":\"i\"}\n" +
+			"data: [DONE]\n",
+	)
+
+	results, done := StartParsedLinePump(context.Background(), body, false, "text")
+
+	collected := make([]LineResult, 0)
+	for r := range results {
+		collected = append(collected, r)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 2 {
+		t.Fatalf("expected 2 results (accumulated content + done), got %d", len(collected))
+	}
+	if len(collected[0].Parts) != 2 {
+		t.Fatalf("expected 2 accumulated parts, got %d", len(collected[0].Parts))
+	}
+	if !collected[1].Stop {
+		t.Fatal("expected second result to stop")
 	}
 }


### PR DESCRIPTION
### Motivation
- 修复 issue #361 中的上游 DeepSeek SSE 流粒度过细导致客户端（如 OpenClaw / Hermes Agent）超时的问题。 
- 目标是在不破坏控制事件顺序的前提下，减少下游被逐字符/逐空格拆分的 SSE 事件数量以改善兼容性和稳定性。 

### Description
- 在 `internal/sse/stream.go` 的 `StartParsedLinePump` 中增加了聚合逻辑，新增常量 `minFlushChars`（默认 160）和 `maxFlushWait`（默认 80ms）用于字符阈值和时间阈值的双重触发。 
- 将扫描拆成独立 reader goroutine + 主循环 `select`（支持 `ctx`、定时器和行通道），以便实现定时刷新与及时取消。 
- 仅对普通内容增量结果累积（根据 `LineResult` 的字段判断），在遇到 stop / error / content_filter / 非内容行时先 flush 再发送控制事件，并在流结束时强制 flush。 
- 新增测试 `TestStartParsedLinePumpAccumulatesSmallChunks` 并调整现有多行测试的期望，使其与聚合语义一致；变更文件为 `internal/sse/stream.go` 和 `internal/sse/stream_edge_test.go`。 

### Testing
- 运行并通过了 `./scripts/lint.sh`。 
- 运行并通过了 `./tests/scripts/check-refactor-line-gate.sh`。 
- 运行并通过了单元测试套件 `./tests/scripts/run-unit-all.sh`（所有测试通过）。 
- 运行并通过了 `npm run build --prefix webui`。 
- 单独执行 `go test ./internal/sse -run TestStartParsedLinePump` 验证了相关流处理用例通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1e0f06bec8333b1b4c159a03c4c10)