### PR TITLE
fix(vercel): align JS stream parser with Go object-shaped content

### DIFF
--- a/internal/js/chat-stream/sse_parse_impl.js
+++ b/internal/js/chat-stream/sse_parse_impl.js
@@ -308,6 +308,10 @@ function parseChunkForContent(chunk, thinkingEnabled, currentType, stripReferenc
   }
 
   if (val && typeof val === 'object') {
+    const directContent = asContentString(val, stripReferenceMarkers);
+    if (directContent) {
+      parts.push({ text: directContent, type: partType });
+    }
     const resp = val.response && typeof val.response === 'object' ? val.response : val;
     if (Array.isArray(resp.fragments)) {
       for (const frag of resp.fragments) {
@@ -592,6 +596,12 @@ function asContentString(v, stripReferenceMarkers = true) {
     }
     if (Object.prototype.hasOwnProperty.call(v, 'v')) {
       return asContentString(v.v, stripReferenceMarkers);
+    }
+    if (Object.prototype.hasOwnProperty.call(v, 'text')) {
+      return asContentString(v.text, stripReferenceMarkers);
+    }
+    if (Object.prototype.hasOwnProperty.call(v, 'value')) {
+      return asContentString(v.value, stripReferenceMarkers);
     }
     return '';
   }

--- a/tests/node/chat-stream.test.js
+++ b/tests/node/chat-stream.test.js
@@ -227,6 +227,20 @@ test('vercel stream exhausts DeepSeek continue before synthetic retry', async ()
   assert.equal(fetchBodies.some((body) => String(body.prompt || '').includes('Previous reply had no visible output')), false);
 });
 
+
+
+test('vercel stream usage completion_tokens does not double-count visible output', async () => {
+  const sample = 'abcdefghijklmnopqrst';
+  const { frames } = await runMockVercelStream([
+    `data: ${JSON.stringify({ p: 'response/content', v: sample })}\n\n`,
+    'data: [DONE]\n\n',
+  ]);
+  const parsed = frames.filter((frame) => frame !== '[DONE]').map((frame) => JSON.parse(frame));
+  const terminal = parsed.find((item) => Array.isArray(item.choices) && item.choices[0] && item.choices[0].finish_reason);
+  assert.ok(terminal);
+  assert.equal(terminal.usage.completion_tokens, 5);
+});
+
 test('vercel stream reuses prior PoW when refresh fails', async () => {
   const originalFetch = global.fetch;
   const fetchURLs = [];
@@ -523,6 +537,12 @@ test('parseChunkForContent supports wrapped response.fragments object shape', ()
   const parsed = parseChunkForContent(chunk, false, 'text');
   assert.equal(parsed.finished, false);
   assert.equal(parsed.parts.map((p) => p.text).join(''), 'AB');
+});
+
+test('parseChunkForContent reads object-shaped response/content payloads (Go parity)', () => {
+  const parsed = parseChunkForContent({ p: 'response/content', v: { text: 'vision text' } }, false, 'text', true);
+  assert.equal(parsed.parsed, true);
+  assert.deepEqual(parsed.parts, [{ text: 'vision text', type: 'text' }]);
 });
 
 test('parseChunkForContent preserves space-only content tokens', () => {


### PR DESCRIPTION
### Motivation

- 近期上游 vision 模型的 SSE 输出出现了对象化的内容变体（例如 `v: { text: ... }` / `v: { value: ... }`），导致 Vercel Node 流路径在非字符串 payload 下丢内容或与后端 Go 行为不一致。 
- 目标是在 Vercel Node 流实现中补齐对这些对象形态的兼容，保证在 Vercel 部署时对 vision 接口的可调用性与 Go 后端行为一致。 

### Description

- 在 `internal/js/chat-stream/sse_parse_impl.js` 中扩展了 `parseChunkForContent` / `asContentString`，使解析器能从对象形态中提取 `content`、`v`、`text`、`value` 等字段并作为可见文本处理，支持顶层对象型 `response/content` 值。 
- 新增/修改了单测 `tests/node/chat-stream.test.js`，增加了对对象形态 `response/content` 的回归覆盖以及一个 usage 计数回归用例，防止可见输出被双计数或被忽略。 
- 保持变更尽量局部且向后兼容，仅在 JS 流解析链中增强对内容形态的容错，不改变已有上游协议或 Go-side 行为。 

### Testing

- 运行 `./scripts/lint.sh` 并通过（无 lint 错误）。
- 运行 `./tests/scripts/check-refactor-line-gate.sh` 并通过（检查通过）。
- 运行 `./tests/scripts/run-unit-all.sh`（含 Go 单元测试和 Node 单元测试）并通过，所有 Node 流相关测试通过（Node 测试套件通过率 100%）。
- 运行 `npm run build --prefix webui` 并成功构建 WebUI（Vite 构建成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2289162708333810fcfd1fd01a0da)