### PR TITLE
fix: increase stream timeout constants for large-context models; guar…

### DIFF
--- a/internal/deepseek/protocol/constants.go
+++ b/internal/deepseek/protocol/constants.go
@@ -159,6 +159,6 @@ func toStringSet(in []string) map[string]struct{} {
 
 const (
 	KeepAliveTimeout  = 5
-	StreamIdleTimeout = 90
-	MaxKeepaliveCount = 10
+	StreamIdleTimeout = 300
+	MaxKeepaliveCount = 40
 )

--- a/internal/httpapi/openai/chat/empty_retry_runtime.go
+++ b/internal/httpapi/openai/chat/empty_retry_runtime.go
@@ -252,6 +252,9 @@ func (h *Handler) consumeChatStreamAttempt(r *http.Request, resp *http.Response,
 			}
 		},
 	})
+	if r.Context().Err() != nil {
+		return true, false
+	}
 	terminalWritten := streamRuntime.finalize(finalReason, allowDeferEmpty && finalReason != "content_filter")
 	if terminalWritten {
 		recordChatStreamHistory(streamRuntime, historySession)

--- a/internal/httpapi/openai/responses/empty_retry_runtime.go
+++ b/internal/httpapi/openai/responses/empty_retry_runtime.go
@@ -223,6 +223,9 @@ func (h *Handler) consumeResponsesStreamAttempt(r *http.Request, resp *http.Resp
 			}
 		},
 	})
+	if r.Context().Err() != nil {
+		return true, false
+	}
 	terminalWritten := streamRuntime.finalize(finalReason, allowDeferEmpty && finalReason != "content_filter")
 	if terminalWritten {
 		return true, false


### PR DESCRIPTION

**标题：**

```
fix: 提升流引擎超时阈值，修复上下文取消后历史记录覆盖问题
```

**变更类型：**

- [x] 🐛 fix

**变更说明：**

```markdown
## 问题描述

1. **大上下文模型流式中断**：使用 DeepSeek V4 Pro 处理 ~50K token 上下文时，ds2api 会在模型首次返回 token 之前就主动终止 SSE 流连接。客户端（如 Hermes Agent）因此报错 "No response from provider for 180s"，任务无法完成。

2. **历史记录状态覆盖**：当 HTTP 请求被取消时（如客户端断开连接），`OnContextDone` 已正确记录 `stopped()`，但后续 `finalize()` 因空输出触发重试逻辑，导致 `error()` 覆盖了之前的正确状态。

## 超时链路分析

```
DeepSeek V4 Pro（47K tokens 上下文）→ 首次 token 延迟 > 60s
     ↓
ConsumeSSE 引擎心跳每 5s 触发一次
     ↓
keepaliveCount >= MaxKeepaliveCount(10) → 50s 后判定超时
     ↓
ds2api 关闭 SSE 连接 → Hermes 报 "No response for 180s"
```

`MaxKeepaliveCount=10` 意味着 10×5s = **50 秒**无内容即终止，这对大上下文模型过于激进。

## 修改内容

| 文件 | 修改 |
|------|------|
| `internal/deepseek/protocol/constants.go` | `StreamIdleTimeout` 90→300，`MaxKeepaliveCount` 10→40 |
| `internal/httpapi/openai/chat/empty_retry_runtime.go` | ConsumeSSE 后增加 `ctx.Err()` 检查防双重记录 |
| `internal/httpapi/openai/responses/empty_retry_runtime.go` | 同上 |

## 修复效果

- 流引擎无内容容忍时间从 50s 提升至 **200s**（40×5s），足以覆盖 Hermes Agent 的 180s 超时
- 有内容后的空闲超时从 90s 提升至 **300s**（5 分钟）
- 上下文取消后不再覆盖 historySession 的正常状态

## 影响范围

所有通过 `ConsumeSSE` 引擎的流式路径均生效：OpenAI Chat、Responses、Claude、Gemini 接口。
```

**补充信息：**

```markdown
- 超时常量修改为全局常量，所有路由统一生效
- 上下文取消检查仅在 `r.Context().Err() != nil` 时提前返回，不影响正常流程
- 所有修改已通过 `./scripts/lint.sh` 和核心包单元测试
```