### PR TITLE
[codex] drop obsolete release smoke check

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Release Blocking Gates
         run: |
-          ./tests/scripts/check-stage6-manual-smoke.sh
           ./tests/scripts/check-refactor-line-gate.sh
           ./tests/scripts/run-unit-all.sh
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -60,10 +60,9 @@ npm run build --prefix webui
 ./tests/scripts/check-refactor-line-gate.sh
 ./tests/scripts/check-node-split-syntax.sh
 ./tests/scripts/check-cross-build.sh
-
-# 历史阶段门禁：阶段 6 手工烟测签字检查（默认读取 plans/stage6-manual-smoke.md）
-./tests/scripts/check-stage6-manual-smoke.sh
 ```
+
+说明：`plans/stage6-manual-smoke.md` 已移除，阶段 6 手工烟测不再作为当前 CI 或发布门禁。
 
 ### 端到端测试 | End-to-End Tests
 


### PR DESCRIPTION
## What changed
- Removed the obsolete stage 6 manual smoke gate from the Release Artifacts workflow.
- Updated the testing docs to note that the historical smoke file was removed and is no longer part of active CI or release gates.

## Why
- The v4.3.0 release tag deleted `plans/stage6-manual-smoke.md`, but the release workflow still invoked `check-stage6-manual-smoke.sh` and failed as soon as that file was missing.

## Impact
- Release publishes no longer hard-fail on the removed planning artifact.
- The remaining release blocking checks and build steps stay in place.

## Validation
- `./scripts/lint.sh`
- `./tests/scripts/check-refactor-line-gate.sh`
- `./tests/scripts/run-unit-all.sh`
- `npm run build --prefix webui`
