### PR TITLE
fix(webui): 修复 Windows 注册表 MIME 错误导致 /admin 样式失效

### DIFF
--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -55,6 +55,45 @@ func (h *Handler) admin(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "WebUI not built. Run `cd webui && npm run build` first.", http.StatusNotFound)
 }
 
+// staticContentTypes pins the Content-Type of common WebUI assets so we do not
+// rely on mime.TypeByExtension, which on Windows consults the registry and can
+// return the wrong type (e.g. application/xml for .css) when third-party
+// software has overwritten HKEY_CLASSES_ROOT entries. Browsers strictly enforce
+// stylesheet/script MIME types and will refuse to apply a misidentified asset,
+// breaking the /admin page on affected machines.
+var staticContentTypes = map[string]string{
+	".css":   "text/css; charset=utf-8",
+	".js":    "text/javascript; charset=utf-8",
+	".mjs":   "text/javascript; charset=utf-8",
+	".html":  "text/html; charset=utf-8",
+	".htm":   "text/html; charset=utf-8",
+	".json":  "application/json; charset=utf-8",
+	".map":   "application/json; charset=utf-8",
+	".svg":   "image/svg+xml",
+	".png":   "image/png",
+	".jpg":   "image/jpeg",
+	".jpeg":  "image/jpeg",
+	".gif":   "image/gif",
+	".webp":  "image/webp",
+	".ico":   "image/x-icon",
+	".woff":  "font/woff",
+	".woff2": "font/woff2",
+	".ttf":   "font/ttf",
+	".otf":   "font/otf",
+	".txt":   "text/plain; charset=utf-8",
+	".wasm":  "application/wasm",
+}
+
+// setStaticContentType pins the response Content-Type by file extension so that
+// http.ServeFile does not fall back to mime.TypeByExtension (which on Windows
+// reads the registry and may return an incorrect type).
+func setStaticContentType(w http.ResponseWriter, fullPath string) {
+	ext := strings.ToLower(filepath.Ext(fullPath))
+	if ct, ok := staticContentTypes[ext]; ok {
+		w.Header().Set("Content-Type", ct)
+	}
+}
+
 func (h *Handler) serveFromDisk(w http.ResponseWriter, r *http.Request, staticDir string) {
 	path := strings.TrimPrefix(r.URL.Path, "/admin")
 	path = strings.TrimPrefix(path, "/")
@@ -70,6 +109,7 @@ func (h *Handler) serveFromDisk(w http.ResponseWriter, r *http.Request, staticDi
 			} else {
 				w.Header().Set("Cache-Control", "no-store, must-revalidate")
 			}
+			setStaticContentType(w, full)
 			http.ServeFile(w, r, full)
 			return
 		}
@@ -82,6 +122,7 @@ func (h *Handler) serveFromDisk(w http.ResponseWriter, r *http.Request, staticDi
 		return
 	}
 	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	setStaticContentType(w, index)
 	http.ServeFile(w, r, index)
 }
 

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -1,0 +1,102 @@
+package webui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestServeFromDiskPinsContentType ensures static admin assets are returned
+// with an explicit, RFC-compliant Content-Type that does not depend on
+// mime.TypeByExtension. On Windows mime.TypeByExtension consults the registry
+// (HKEY_CLASSES_ROOT) which third-party software can corrupt — for example
+// installing certain editors rewrites .css to application/xml — and Chrome
+// then refuses to apply a stylesheet whose Content-Type is not text/css,
+// breaking the /admin page entirely. Pinning the type by file extension makes
+// the response deterministic across operating systems and machine state.
+func TestServeFromDiskPinsContentType(t *testing.T) {
+	staticDir := t.TempDir()
+	assetsDir := filepath.Join(staticDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
+		t.Fatalf("mkdir assets: %v", err)
+	}
+
+	files := map[string]string{
+		"index.html":           "<!doctype html><html></html>",
+		"assets/index.css":     "body{}",
+		"assets/index.js":      "console.log(1)",
+		"assets/icon.svg":      `<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+		"assets/source.js.map": `{"version":3}`,
+	}
+	for rel, body := range files {
+		full := filepath.Join(staticDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	h := &Handler{StaticDir: staticDir}
+
+	cases := []struct {
+		urlPath      string
+		wantPrefix   string
+		wantCacheCtl string
+	}{
+		{"/admin/assets/index.css", "text/css", "public, max-age=31536000, immutable"},
+		{"/admin/assets/index.js", "text/javascript", "public, max-age=31536000, immutable"},
+		{"/admin/assets/icon.svg", "image/svg+xml", "public, max-age=31536000, immutable"},
+		{"/admin/assets/source.js.map", "application/json", "public, max-age=31536000, immutable"},
+		// "/admin/index.html" is intentionally omitted: http.ServeFile redirects
+		// requests for index.html to "./", matching Go's net/http behavior. The
+		// route the SPA actually lands on is "/admin/" below.
+		{"/admin/", "text/html", "no-store, must-revalidate"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.urlPath, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
+			rec := httptest.NewRecorder()
+			h.serveFromDisk(rec, req, staticDir)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			ct := rec.Header().Get("Content-Type")
+			if !strings.HasPrefix(ct, tc.wantPrefix) {
+				t.Fatalf("Content-Type = %q, want prefix %q", ct, tc.wantPrefix)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != tc.wantCacheCtl {
+				t.Fatalf("Cache-Control = %q, want %q", got, tc.wantCacheCtl)
+			}
+		})
+	}
+}
+
+// TestSetStaticContentTypeUnknownExtensionFallsThrough verifies that unknown
+// extensions leave the Content-Type header unset, so http.ServeFile can apply
+// its own detection (sniffing or mime.TypeByExtension) for cases the pinned
+// table does not cover.
+func TestSetStaticContentTypeUnknownExtensionFallsThrough(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setStaticContentType(rec, "/tmp/data.unknownext")
+	if got := rec.Header().Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want empty for unknown extension", got)
+	}
+}
+
+// TestSetStaticContentTypeIsCaseInsensitive guards against a regression where
+// uppercase extensions (e.g. STYLE.CSS shipped from some build pipelines)
+// would bypass the pinned table and fall back to the registry on Windows.
+func TestSetStaticContentTypeIsCaseInsensitive(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setStaticContentType(rec, "/tmp/STYLE.CSS")
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/css") {
+		t.Fatalf("Content-Type = %q, want text/css prefix", got)
+	}
+}


### PR DESCRIPTION
 ## 问题现象

  在某些 Windows 环境下，访问 `/admin` 管理面板时所有 CSS 样式失效，页面变成白底黑字无布局。Chrome DevTools → Network
  检查 CSS 请求，会发现响应头 `Content-Type` 是 `application/xml` 而非 `text/css`，浏览器因 MIME
  严格检查直接拒绝应用样式表。

  同样的问题也可能影响 `.js`（被识别成 `text/plain` 时浏览器会拒绝执行）。

  Linux / macOS / Docker 部署完全不受影响。

  ## 根本原因

  `internal/webui/handler.go` 中 `serveFromDisk` 使用 `http.ServeFile` 服务 `static/admin/` 下的资源。`http.ServeFile`
  在没有显式 `Content-Type` 时会调 `mime.TypeByExtension`，该函数在 Windows 上会读取注册表
  `HKEY_CLASSES_ROOT\<ext>\Content Type`。

  部分第三方软件（IDE / 编辑器 / 注册表清理工具 / 某些版本的 Office 安装包）会无意中改写这些注册表项，最常见的就是
  `.css` 被改成 `application/xml`、`.js` 被改成 `text/plain`。一旦中招，所有依赖系统 MIME 表的 Go 程序都会受影响。

  参考：
  - Go `mime.TypeByExtension` 文档（Windows 段）：https://pkg.go.dev/mime#TypeByExtension
  - Go issue 32350（同类问题历史讨论）：https://github.com/golang/go/issues/32350

  ## 修复方案

  在 `serveFromDisk` 内、调用 `http.ServeFile` 之前，根据文件扩展名预先 `Set("Content-Type", ...)`。`http.ServeContent`
  文档明确说：调用方已设置 `Content-Type` 时不会被覆盖。

  固定的扩展名映射表覆盖 WebUI 实际产出的资源类型（CSS / JS / JSON / SourceMap / 图片 / 字体 / WASM
  等），未列入的扩展名仍然落到 `ServeFile` 的默认检测，行为完全保持向后兼容。

  修改保持加性、最小化，**只影响 `/admin` 静态资源服务路径**，不触碰任何 API 路由、CORS、缓存或路由注册逻辑。

  ## 测试

  新增 `internal/webui/handler_test.go`，覆盖：
  - 主流资源类型（CSS / JS / SVG / source map / index.html）的 `Content-Type` 与 `Cache-Control`
  - 大写扩展名（如 `STYLE.CSS`）的大小写不敏感匹配
  - 未知扩展名时不污染 header（保留 ServeFile 的回退能力）

  ## 本地验证（按 AGENTS.md PR Gate）

  - ✅ `gofmt -l` 干净
  - ✅ `golangci-lint` 对修改的文件无 issue
  - ✅ `bash ./tests/scripts/check-refactor-line-gate.sh`：`checked=0 missing=0 over_limit=0`
  - ✅ `bash ./tests/scripts/run-unit-all.sh`：全部通过（含新增 webui 测试）
  - ✅ `npm run build --prefix webui`：built in 1.03s

  ## 影响范围

  - ✅ 修复 Windows 用户访问 `/admin` 时 CSS / JS 失效问题
  - ✅ Linux / macOS / Docker / Vercel 部署行为不变（这些环境本来就走 Go 内置 mime 表，不读注册表）
  - ✅ 不改变 API、路由、CORS 等其他子系统