### PR TITLE
fix(openai): avoid empty choices stream heartbeat

### DIFF
--- a/internal/httpapi/openai/chat/chat_stream_runtime.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime.go
@@ -127,13 +127,7 @@ func (s *chatStreamRuntime) sendKeepAlive() {
 		return
 	}
 	_, _ = s.w.Write([]byte(": keep-alive\n\n"))
-	s.sendChunk(openaifmt.BuildChatStreamChunk(
-		s.completionID,
-		s.created,
-		s.model,
-		[]map[string]any{},
-		nil,
-	))
+	_ = s.rc.Flush()
 }
 
 func (s *chatStreamRuntime) sendChunk(v any) {

--- a/internal/httpapi/openai/chat/chat_stream_runtime_test.go
+++ b/internal/httpapi/openai/chat/chat_stream_runtime_test.go
@@ -10,7 +10,7 @@ import (
 	"ds2api/internal/promptcompat"
 )
 
-func TestChatStreamKeepAliveEmitsEmptyChoiceDataFrame(t *testing.T) {
+func TestChatStreamKeepAliveUsesCommentOnly(t *testing.T) {
 	rec := httptest.NewRecorder()
 	runtime := newChatStreamRuntime(
 		rec,
@@ -40,18 +40,8 @@ func TestChatStreamKeepAliveEmitsEmptyChoiceDataFrame(t *testing.T) {
 	if done {
 		t.Fatalf("keep-alive must not emit [DONE], body=%q", body)
 	}
-	if len(frames) != 1 {
-		t.Fatalf("expected one data frame, got %d body=%q", len(frames), body)
-	}
-	if got := asString(frames[0]["id"]); got != "chatcmpl-test" {
-		t.Fatalf("expected completion id to be preserved, got %q", got)
-	}
-	if got := asString(frames[0]["object"]); got != "chat.completion.chunk" {
-		t.Fatalf("expected chat chunk object, got %q", got)
-	}
-	choices, _ := frames[0]["choices"].([]any)
-	if len(choices) != 0 {
-		t.Fatalf("expected empty choices heartbeat, got %#v", choices)
+	if len(frames) != 0 {
+		t.Fatalf("keep-alive must not emit JSON data frames, got %#v body=%q", frames, body)
 	}
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fixes #429.

OpenAI Chat Completions streaming currently sends keep-alive traffic as both an SSE comment and a JSON `chat.completion.chunk` with `choices: []`. Some strict OpenAI-compatible clients index `choices[0]` for every data frame, so that heartbeat chunk can raise `IndexError: list index out of range` and abort an otherwise healthy stream.

This change keeps the heartbeat as a valid SSE comment only:

- preserve `: keep-alive\n\n` and flush behavior so idle streams still stay warm
- stop emitting a JSON data frame with an empty `choices` array
- update the regression test to assert keep-alives do not produce JSON data frames or `[DONE]`

Duplicate check: searched open PRs/issues for `choices` / empty choices / `IndexError`; the currently open PRs (#422, #407, #405) cover unrelated read-cache, WebUI env, and multi-turn work.

#### 📝 补充信息 | Additional Information

Validation run locally with portable Go 1.26.0:

- `gofmt -w internal/httpapi/openai/chat/chat_stream_runtime.go internal/httpapi/openai/chat/chat_stream_runtime_test.go`
- `go test ./internal/httpapi/openai/chat -run TestChatStreamKeepAliveUsesCommentOnly -count=1`
- `go test ./internal/httpapi/openai/chat -count=1`
- `go test ./internal/httpapi/openai/... -count=1`
- `go test ./... -count=1`
- `git diff --check`