### PR TITLE
fix: auto-detect Vercel for chat history path

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -58,6 +58,11 @@ func RawStreamSampleRoot() string {
 }
 
 func ChatHistoryPath() string {
+	// On Vercel, /var/task is read-only at runtime. If no explicit path is set,
+	// default to /tmp/chat_history.json (the only writable directory).
+	if IsVercel() && strings.TrimSpace(os.Getenv("DS2API_CHAT_HISTORY_PATH")) == "" {
+		return "/tmp/chat_history.json"
+	}
 	return ResolvePath("DS2API_CHAT_HISTORY_PATH", "data/chat_history.json")
 }
 


### PR DESCRIPTION
## Summary

On Vercel, `/var/task` is read-only at runtime. The chat history module previously tried to create directories under `/var/task/data/`, which fails with:

```
create chat history dir: mkdir /var/task/data: read-only file system
```

## Fix

Modified `ChatHistoryPath()` in `internal/config/paths.go` to auto-detect Vercel via the existing `IsVercel()` function. When running on Vercel and no explicit `DS2API_CHAT_HISTORY_PATH` env var is set, it now defaults to `/tmp/chat_history.json` (the only writable directory on Vercel Serverless).

If the user explicitly sets `DS2API_CHAT_HISTORY_PATH`, that value is still respected as an override.

## Changes

- `internal/config/paths.go`: +5 lines in `ChatHistoryPath()`

## Verification

- `go build -o /dev/null ./cmd/ds2api/` passes
- Backward compatible: non-Vercel environments still use the original default `data/chat_history.json`