### PR TITLE
抽取通用 ASCII 部分前缀匹配以合并重复的 DSML 前缀逻辑

### DIFF
--- a/internal/toolcall/toolcalls_scan.go
+++ b/internal/toolcall/toolcalls_scan.go
@@ -204,7 +204,7 @@ func IsPartialToolMarkupTagPrefix(text string) bool {
 		if hasToolMarkupNamePrefix(text, i) {
 			return true
 		}
-		if hasDSMLPrefix(text, i) {
+		if hasASCIIPartialPrefixFoldAt(text, i, "dsml") {
 			return true
 		}
 		next, ok := consumeToolMarkupNamePrefixOnce(text, i)
@@ -245,15 +245,13 @@ func consumeToolMarkupNamePrefixOnce(text string, idx int) (int, bool) {
 	return idx, false
 }
 
-// hasDSMLPrefix checks if "dsml" starts with text[start:] (case-insensitive).
-func hasDSMLPrefix(text string, start int) bool {
-	const dsml = "dsml"
+func hasASCIIPartialPrefixFoldAt(text string, start int, prefix string) bool {
 	remain := len(text) - start
-	if remain <= 0 || remain > len(dsml) {
+	if remain <= 0 || remain > len(prefix) {
 		return false
 	}
 	for j := 0; j < remain; j++ {
-		if asciiLower(text[start+j]) != dsml[j] {
+		if asciiLower(text[start+j]) != asciiLower(prefix[j]) {
 			return false
 		}
 	}
@@ -265,18 +263,8 @@ func hasToolMarkupNamePrefix(text string, start int) bool {
 		if hasASCIIPrefixFoldAt(text, start, name.raw) {
 			return true
 		}
-		tailLen := len(text) - start
-		if tailLen > 0 && tailLen <= len(name.raw) {
-			match := true
-			for j := 0; j < tailLen; j++ {
-				if asciiLower(text[start+j]) != asciiLower(name.raw[j]) {
-					match = false
-					break
-				}
-			}
-			if match {
-				return true
-			}
+		if hasASCIIPartialPrefixFoldAt(text, start, name.raw) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
### Motivation
- 代码中存在两处几乎相同的 ASCII 大小写不敏感的“部分前缀”匹配实现，导致重复逻辑并增加维护成本。 

### Description
- 在 `internal/toolcall/toolcalls_scan.go` 中新增 `hasASCIIPartialPrefixFoldAt(text, start, prefix string) bool`，用于通用的 ASCII 部分前缀折叠匹配。 
- 移除了原有的 `hasDSMLPrefix` 专门实现，并将其在 `IsPartialToolMarkupTagPrefix` 中的调用替换为新的通用函数。 
- 将 `hasToolMarkupNamePrefix` 里原先内联的 partial-prefix 比较替换为复用新的 helper，从而去除了重复代码。 
- 本次变更为纯重构，不改变匹配行为或对外 API。 

### Testing
- 运行 `./scripts/lint.sh` 成功并报告 `0 issues`。 
- 运行 `./tests/scripts/check-refactor-line-gate.sh` 成功（`checked=0 missing=0 over_limit=0`）。 
- 运行 `./tests/scripts/run-unit-all.sh`，所有单元测试通过（111 个子测试全部通过）。 
- 运行 `npm run build --prefix webui` 构建成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff048d48288333817967b11013f566)