### PR TITLE
fix(vercel): align JS stream path guard with Go /chat/completions alias

### DIFF
--- a/internal/js/chat-stream/index.js
+++ b/internal/js/chat-stream/index.js
@@ -88,7 +88,7 @@ function isVercelRuntime() {
 
 function isNodeStreamSupportedPath(rawURL) {
   const path = extractPathname(rawURL);
-  return path === '/v1/chat/completions';
+  return path === '/v1/chat/completions' || path === '/chat/completions';
 }
 
 function extractPathname(rawURL) {

--- a/tests/node/chat-stream.test.js
+++ b/tests/node/chat-stream.test.js
@@ -758,9 +758,11 @@ test('shouldSkipPath skips dynamic response/fragments/*/status paths only', () =
   assert.equal(shouldSkipPath('response/status'), false);
 });
 
-test('node stream path guard only allows /v1/chat/completions', () => {
+test('node stream path guard allows OpenAI v1 and root alias chat completions paths', () => {
   assert.equal(isNodeStreamSupportedPath('/v1/chat/completions'), true);
   assert.equal(isNodeStreamSupportedPath('/v1/chat/completions?x=1'), true);
+  assert.equal(isNodeStreamSupportedPath('/chat/completions'), true);
+  assert.equal(isNodeStreamSupportedPath('/chat/completions?x=1'), true);
   assert.equal(isNodeStreamSupportedPath('/v1beta/models/gemini-2.5-flash:streamGenerateContent'), false);
   assert.equal(isNodeStreamSupportedPath('/anthropic/v1/messages'), false);
 });
@@ -768,6 +770,7 @@ test('node stream path guard only allows /v1/chat/completions', () => {
 test('extractPathname strips query only', () => {
   assert.equal(extractPathname('/v1/chat/completions?stream=true'), '/v1/chat/completions');
   assert.equal(extractPathname('/v1beta/models/gemini-2.5-flash:streamGenerateContent?key=1'), '/v1beta/models/gemini-2.5-flash:streamGenerateContent');
+  assert.equal(extractPathname('/chat/completions?stream=true'), '/chat/completions');
 });
 
 test('setCorsHeaders reflects requested third-party headers and blocks internal-only headers', () => {


### PR DESCRIPTION
### Motivation
- 使 Node (Vercel) 端的流式路径守卫与 Go 路由一致，避免 `/chat/completions` 根别名在 Vercel 部署时落到 Go 路径之外导致的体验不一致或行为差异。

### Description
- 在 `internal/js/chat-stream/index.js` 中把路径判断扩展为同时接受 `/v1/chat/completions` 与 `/chat/completions`，使 Node 端流式处理与 Go 路由别名保持一致。 
- 更新 `tests/node/chat-stream.test.js` 中相关断言以覆盖根别名和带查询字符串的情况，防止回归。 

### Testing
- 运行了本仓库质量门控脚本 `./scripts/lint.sh`，结果通过。 
- 运行 `./tests/scripts/check-refactor-line-gate.sh`，结果通过。 
- 运行全部单元测试 `./tests/scripts/run-unit-all.sh`，所有测试通过。 
- 构建 WebUI `npm run build --prefix webui` 成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff082bfff88333888c9ecbb4050994)