### PR TITLE
Align Vercel JS CORS Vary-Origin behavior with Go

### DIFF
--- a/internal/js/chat-stream/cors.js
+++ b/internal/js/chat-stream/cors.js
@@ -19,13 +19,15 @@ const BLOCKED_CORS_REQUEST_HEADERS = new Set([
 function setCorsHeaders(res, req) {
   const origin = asString(readHeader(req, 'origin'));
   res.setHeader('Access-Control-Allow-Origin', origin || '*');
+  if (origin) {
+    addVaryHeader(res, 'Origin');
+  }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');
   res.setHeader('Access-Control-Max-Age', '600');
   res.setHeader(
     'Access-Control-Allow-Headers',
     buildCORSAllowHeaders(req),
   );
-  addVaryHeader(res, 'Origin');
   addVaryHeader(res, 'Access-Control-Request-Headers');
   if (asString(readHeader(req, 'access-control-request-private-network')).toLowerCase() === 'true') {
     res.setHeader('Access-Control-Allow-Private-Network', 'true');


### PR DESCRIPTION
### Motivation
- 发现 Vercel Node 路径（JS）在 `setCorsHeaders` 中无条件添加 `Vary: Origin`，而 Go 实现（`internal/server/router.go`）仅在请求含 `Origin` 时才添加，导致缓存语义在两边不一致，需要对齐以保证部署体验一致。

### Description
- 修改 `internal/js/chat-stream/cors.js`，使 `Vary: Origin` 仅在请求含 `Origin` 头时调用 `addVaryHeader(res, 'Origin')`，从而与 Go 端行为一致（此前为无条件添加）。

### Testing
- 运行仓库质量门并构建：`./scripts/lint.sh`、`./tests/scripts/check-refactor-line-gate.sh`、`./tests/scripts/run-unit-all.sh` 和 `npm run build --prefix webui`，均通过；并运行 Node 测试 `node --test --test-concurrency=1 tests/node/chat-stream.test.js`，所有相关测试通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff082bfff88333888c9ecbb4050994)