### PR TITLE
docs: clarify Vercel chat-stream supports root `/chat/completions` alias

### DIFF
--- a/API.en.md
+++ b/API.en.md
@@ -243,6 +243,8 @@ Retired historical families such as `claude-1.*`, `claude-2.*`, `claude-instant-
 
 ### `POST /v1/chat/completions`
 
+> Path note: besides the canonical `/v1/chat/completions`, DS2API also accepts the root shortcut `/chat/completions`. On Vercel Runtime, `stream=true` on either path is handled by the Node streaming bridge, while non-stream stays on the Go primary path.
+
 **Headers**:
 
 ```http

--- a/API.md
+++ b/API.md
@@ -249,6 +249,8 @@ OpenAI `/v1/*` 仍是规范路径。对于只配置 DS2API 根地址的客户端
 
 ### `POST /v1/chat/completions`
 
+> 路径说明：除规范路径 `/v1/chat/completions` 外，也支持根路径快捷别名 `/chat/completions`；在 Vercel Runtime 上，这两个路径的 `stream=true` 请求都会进入 Node 流式桥接逻辑，非流式仍走 Go 主链路。
+
 **请求头**：
 
 ```http

--- a/README.MD
+++ b/README.MD
@@ -295,7 +295,7 @@ cp config.example.json config.json
 base64 < config.json | tr -d '\n'
 ```
 
-> **流式说明**：`/v1/chat/completions` 在 Vercel 上默认走 `api/chat-stream.js`（Node Runtime）以保证实时 SSE。鉴权、账号选择、会话/PoW 准备仍由 Go 内部 prepare 接口完成；流式响应（含 `tools`）在 Node 侧执行与 Go 对齐的输出组装与防泄漏处理。虽然这里只有 OpenAI chat 流式走 Node，但 CORS 放行策略仍与 Go 主路由保持一致，统一覆盖第三方客户端预检场景。
+> **流式说明**：OpenAI Chat 流式在 Vercel 上会由 `api/chat-stream.js`（Node Runtime）承接，支持规范路径 `/v1/chat/completions` 与根路径快捷别名 `/chat/completions`。鉴权、账号选择、会话/PoW 准备仍由 Go 内部 prepare 接口完成；流式响应（含 `tools`）在 Node 侧执行与 Go 对齐的输出组装与防泄漏处理。虽然这里只有 OpenAI chat 流式走 Node，但 CORS 放行策略仍与 Go 主路由保持一致，统一覆盖第三方客户端预检场景。
 
 详细部署说明请参阅 [部署指南](docs/DEPLOY.md)。
 

--- a/README.en.md
+++ b/README.en.md
@@ -283,7 +283,7 @@ Recommended: convert `config.json` to Base64 locally, then paste into `DS2API_CO
 base64 < config.json | tr -d '\n'
 ```
 
-> **Streaming note**: `/v1/chat/completions` on Vercel is routed to `api/chat-stream.js` (Node Runtime) for real-time SSE. Auth, account selection, and session/PoW preparation are still handled by the Go internal prepare endpoint; streaming output (including `tools`) is assembled on Node with Go-aligned anti-leak handling. This is the only interface family currently routed through Node, and its CORS allow behavior is kept aligned with the Go router so third-party preflight handling stays unified.
+> **Streaming note**: OpenAI Chat streaming on Vercel is routed to `api/chat-stream.js` (Node Runtime), with both the canonical `/v1/chat/completions` path and the root shortcut `/chat/completions` supported. Auth, account selection, and session/PoW preparation are still handled by the Go internal prepare endpoint; streaming output (including `tools`) is assembled on Node with Go-aligned anti-leak handling. This is the only interface family currently routed through Node, and its CORS allow behavior is kept aligned with the Go router so third-party preflight handling stays unified.
 
 For detailed deployment instructions, see the [Deployment Guide](docs/DEPLOY.en.md).
 


### PR DESCRIPTION
### Motivation
- 最近对 Vercel 流式桥接的实现做了核对，发现文档只写了规范路径 `/v1/chat/completions`，需要补充说明 Node 流式桥接在 Vercel 上也接受根路径快捷别名 `/chat/completions` 以避免使用者混淆。 

### Description
- 在中英文文档中同步补充了关于 Vercel Node 流式桥接路径的说明，明确同时支持 `/v1/chat/completions` 与根路径 `/chat/completions`，且在 Vercel 上 `stream=true` 的请求会走 Node 流式桥接，非流式请求仍走 Go 主链路。 
- 更新的文件：`README.MD`、`README.en.md`、`API.md`、`API.en.md`。 
- 本次变更仅限文档同步，没有更改业务代码或运行时逻辑。 

### Testing
- 已按仓库 PR 门禁运行本地质量门：`./scripts/lint.sh`（通过）、`./tests/scripts/check-refactor-line-gate.sh`（通过）、`./tests/scripts/run-unit-all.sh`（全部 Go/Node 单元测试通过），以及 `npm run build --prefix webui`（构建成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff0cdf32588333ad029a89ed7220e6)