### PR TITLE
fix(toolcall): unify DSML delimiter in correct examples

### DIFF
--- a/internal/toolcall/tool_prompt.go
+++ b/internal/toolcall/tool_prompt.go
@@ -140,21 +140,21 @@ func firstScriptExample(names []string) (promptToolExample, bool) {
 
 func renderToolExampleBlock(calls []promptToolExample) string {
 	var b strings.Builder
-	b.WriteString("<|DSML|tool_calls>\n")
+	b.WriteString("<｜DSML｜tool_calls>\n")
 	for _, call := range calls {
-		b.WriteString(`  <|DSML|invoke name="`)
+		b.WriteString(`  <｜DSML｜invoke name="`)
 		b.WriteString(call.name)
 		b.WriteString(`">` + "\n")
 		b.WriteString(indentPromptParameters(call.params, "    "))
-		b.WriteString("\n  </|DSML|invoke>\n")
+		b.WriteString("\n  </｜DSML｜invoke>\n")
 	}
-	b.WriteString("</|DSML|tool_calls>")
+	b.WriteString("</｜DSML｜tool_calls>")
 	return b.String()
 }
 
 func indentPromptParameters(body, indent string) string {
 	if strings.TrimSpace(body) == "" {
-		return indent + `<|DSML|parameter name="content"></|DSML|parameter>`
+		return indent + `<｜DSML｜parameter name="content"></｜DSML｜parameter>`
 	}
 	lines := strings.Split(body, "\n")
 	for i, line := range lines {
@@ -168,7 +168,7 @@ func indentPromptParameters(body, indent string) string {
 }
 
 func wrapParameter(name, inner string) string {
-	return `<|DSML|parameter name="` + name + `">` + inner + `</|DSML|parameter>`
+	return `<｜DSML｜parameter name="` + name + `">` + inner + `</｜DSML｜parameter>`
 }
 
 func exampleBasicParams(name string) (string, bool) {
@@ -194,7 +194,7 @@ func exampleBasicParams(name string) (string, bool) {
 	case "Edit":
 		return wrapParameter("file_path", promptCDATA("README.md")) + "\n" + wrapParameter("old_string", promptCDATA("foo")) + "\n" + wrapParameter("new_string", promptCDATA("bar")), true
 	case "MultiEdit":
-		return wrapParameter("file_path", promptCDATA("README.md")) + "\n" + `<|DSML|parameter name="edits"><item><old_string>` + promptCDATA("foo") + `</old_string><new_string>` + promptCDATA("bar") + `</new_string></item></|DSML|parameter>`, true
+		return wrapParameter("file_path", promptCDATA("README.md")) + "\n" + `<｜DSML｜parameter name="edits"><item><old_string>` + promptCDATA("foo") + `</old_string><new_string>` + promptCDATA("bar") + `</new_string></item></｜DSML｜parameter>`, true
 	}
 	return "", false
 }
@@ -202,11 +202,11 @@ func exampleBasicParams(name string) (string, bool) {
 func exampleNestedParams(name string) (string, bool) {
 	switch strings.TrimSpace(name) {
 	case "MultiEdit":
-		return wrapParameter("file_path", promptCDATA("README.md")) + "\n" + `<|DSML|parameter name="edits"><item><old_string>` + promptCDATA("foo") + `</old_string><new_string>` + promptCDATA("bar") + `</new_string></item></|DSML|parameter>`, true
+		return wrapParameter("file_path", promptCDATA("README.md")) + "\n" + `<｜DSML｜parameter name="edits"><item><old_string>` + promptCDATA("foo") + `</old_string><new_string>` + promptCDATA("bar") + `</new_string></item></｜DSML｜parameter>`, true
 	case "Task":
 		return wrapParameter("description", promptCDATA("Investigate flaky tests")) + "\n" + wrapParameter("prompt", promptCDATA("Run targeted tests and summarize failures")), true
 	case "ask_followup_question":
-		return wrapParameter("question", promptCDATA("Which approach do you prefer?")) + "\n" + `<|DSML|parameter name="follow_up"><item><text>` + promptCDATA("Option A") + `</text></item><item><text>` + promptCDATA("Option B") + `</text></item></|DSML|parameter>`, true
+		return wrapParameter("question", promptCDATA("Which approach do you prefer?")) + "\n" + `<｜DSML｜parameter name="follow_up"><item><text>` + promptCDATA("Option A") + `</text></item><item><text>` + promptCDATA("Option B") + `</text></item></｜DSML｜parameter>`, true
 	}
 	return "", false
 }

--- a/internal/toolcall/tool_prompt_test.go
+++ b/internal/toolcall/tool_prompt_test.go
@@ -7,20 +7,20 @@ import (
 
 func TestBuildToolCallInstructions_ExecCommandUsesCmdExample(t *testing.T) {
 	out := BuildToolCallInstructions([]string{"exec_command"})
-	if !strings.Contains(out, `<|DSML|invoke name="exec_command">`) {
+	if !strings.Contains(out, `<｜DSML｜invoke name="exec_command">`) {
 		t.Fatalf("expected exec_command in examples, got: %s", out)
 	}
-	if !strings.Contains(out, `<|DSML|parameter name="cmd"><![CDATA[pwd]]></|DSML|parameter>`) {
+	if !strings.Contains(out, `<｜DSML｜parameter name="cmd"><![CDATA[pwd]]></｜DSML｜parameter>`) {
 		t.Fatalf("expected cmd parameter example for exec_command, got: %s", out)
 	}
 }
 
 func TestBuildToolCallInstructions_ExecuteCommandUsesCommandExample(t *testing.T) {
 	out := BuildToolCallInstructions([]string{"execute_command"})
-	if !strings.Contains(out, `<|DSML|invoke name="execute_command">`) {
+	if !strings.Contains(out, `<｜DSML｜invoke name="execute_command">`) {
 		t.Fatalf("expected execute_command in examples, got: %s", out)
 	}
-	if !strings.Contains(out, `<|DSML|parameter name="command"><![CDATA[pwd]]></|DSML|parameter>`) {
+	if !strings.Contains(out, `<｜DSML｜parameter name="command"><![CDATA[pwd]]></｜DSML｜parameter>`) {
 		t.Fatalf("expected command parameter example for execute_command, got: %s", out)
 	}
 }
@@ -34,20 +34,20 @@ func TestBuildToolCallInstructions_BashUsesCommandAndDescriptionExamples(t *test
 
 	sawDescription := false
 	for _, block := range blocks {
-		if !strings.Contains(block, `<|DSML|parameter name="command">`) {
+		if !strings.Contains(block, `<｜DSML｜parameter name="command">`) {
 			t.Fatalf("expected every Bash example to use command parameter, got: %s", block)
 		}
-		if strings.Contains(block, `<|DSML|parameter name="path">`) || strings.Contains(block, `<|DSML|parameter name="content">`) {
+		if strings.Contains(block, `<｜DSML｜parameter name="path">`) || strings.Contains(block, `<｜DSML｜parameter name="content">`) {
 			t.Fatalf("expected Bash examples not to use file write parameters, got: %s", block)
 		}
-		if strings.Contains(block, `<|DSML|parameter name="description">`) {
+		if strings.Contains(block, `<｜DSML｜parameter name="description">`) {
 			sawDescription = true
 		}
 	}
 	if !sawDescription {
 		t.Fatalf("expected Bash long-script example to include description, got: %s", out)
 	}
-	if strings.Contains(out, `<|DSML|invoke name="Read">`) {
+	if strings.Contains(out, `<｜DSML｜invoke name="Read">`) {
 		t.Fatalf("expected examples to avoid unavailable hard-coded Read tool, got: %s", out)
 	}
 }
@@ -60,10 +60,10 @@ func TestBuildToolCallInstructions_ExecuteCommandLongScriptUsesCommand(t *testin
 	}
 
 	for _, block := range blocks {
-		if !strings.Contains(block, `<|DSML|parameter name="command">`) {
+		if !strings.Contains(block, `<｜DSML｜parameter name="command">`) {
 			t.Fatalf("expected execute_command examples to use command parameter, got: %s", block)
 		}
-		if strings.Contains(block, `<|DSML|parameter name="path">`) || strings.Contains(block, `<|DSML|parameter name="content">`) {
+		if strings.Contains(block, `<｜DSML｜parameter name="path">`) || strings.Contains(block, `<｜DSML｜parameter name="content">`) {
 			t.Fatalf("expected execute_command examples not to use file write parameters, got: %s", block)
 		}
 	}
@@ -80,10 +80,10 @@ func TestBuildToolCallInstructions_ExecCommandLongScriptUsesCmd(t *testing.T) {
 	}
 
 	for _, block := range blocks {
-		if !strings.Contains(block, `<|DSML|parameter name="cmd">`) {
+		if !strings.Contains(block, `<｜DSML｜parameter name="cmd">`) {
 			t.Fatalf("expected exec_command examples to use cmd parameter, got: %s", block)
 		}
-		if strings.Contains(block, `<|DSML|parameter name="command">`) || strings.Contains(block, `<|DSML|parameter name="path">`) || strings.Contains(block, `<|DSML|parameter name="content">`) {
+		if strings.Contains(block, `<｜DSML｜parameter name="command">`) || strings.Contains(block, `<｜DSML｜parameter name="path">`) || strings.Contains(block, `<｜DSML｜parameter name="content">`) {
 			t.Fatalf("expected exec_command examples not to use command or file write parameters, got: %s", block)
 		}
 	}
@@ -100,10 +100,10 @@ func TestBuildToolCallInstructions_WriteUsesFilePathAndContent(t *testing.T) {
 	}
 
 	for _, block := range blocks {
-		if !strings.Contains(block, `<|DSML|parameter name="file_path">`) || !strings.Contains(block, `<|DSML|parameter name="content">`) {
+		if !strings.Contains(block, `<｜DSML｜parameter name="file_path">`) || !strings.Contains(block, `<｜DSML｜parameter name="content">`) {
 			t.Fatalf("expected Write examples to use file_path and content, got: %s", block)
 		}
-		if strings.Contains(block, `<|DSML|parameter name="path">`) {
+		if strings.Contains(block, `<｜DSML｜parameter name="path">`) {
 			t.Fatalf("expected Write examples not to use path, got: %s", block)
 		}
 	}
@@ -120,7 +120,7 @@ func TestBuildToolCallInstructions_AnchorsMissingOpeningWrapperFailureMode(t *te
 }
 
 func findInvokeBlocks(text, name string) []string {
-	open := `<|DSML|invoke name="` + name + `">`
+	open := `<｜DSML｜invoke name="` + name + `">`
 	remaining := text
 	blocks := []string{}
 	for {
@@ -129,11 +129,11 @@ func findInvokeBlocks(text, name string) []string {
 			return blocks
 		}
 		remaining = remaining[start:]
-		end := strings.Index(remaining, `</|DSML|invoke>`)
+		end := strings.Index(remaining, `</｜DSML｜invoke>`)
 		if end < 0 {
 			return blocks
 		}
-		end += len(`</|DSML|invoke>`)
+		end += len(`</｜DSML｜invoke>`)
 		blocks = append(blocks, remaining[:end])
 		remaining = remaining[end:]
 	}


### PR DESCRIPTION
### Motivation
- 统一提示词中示例的 DSML 分隔符以消除与正文中强制说明的不一致，避免模型被示例反向带偏向旧式分隔符。 
- 之前 `BuildToolCallInstructions` 声明仅接受全角 DSML 外壳 `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>`，但正例仍使用 legacy `<|DSML|...>`，需要修正示例以配合迁移策略。

### Description
- 将示例渲染器改为使用全角 DSML 分隔符，修改了 `renderToolExampleBlock`、`wrapParameter`、`indentPromptParameters` 等辅助函数以输出 `<｜DSML｜...>` 形式的标签，并修复了示例中零散的 legacy 标签。 
- 修正了若干示例参数字符串（例如 `MultiEdit`、嵌套参数、长脚本实例）以使用一致的全角 DSML 标签。 
- 同步更新了测试 `internal/toolcall/tool_prompt_test.go` 中的断言与 `findInvokeBlocks` 匹配逻辑以验证全角 DSML 标签存在。 
- 变更文件：`internal/toolcall/tool_prompt.go`、`internal/toolcall/tool_prompt_test.go`。 

### Testing
- 运行 `./scripts/lint.sh`：通过（无 lint 问题）。
- 运行 `./tests/scripts/check-refactor-line-gate.sh`：通过（检验项通过）。
- 运行 `./tests/scripts/run-unit-all.sh`：最终通过；变更前因示例标签不一致导致相关测试失败，更新后所有单元测试通过。 
- 运行 `npm run build --prefix webui`：通过（前端构建成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff16c2aeb483338998a311881191c3)