### PR TITLE
fix(vercel): 解决 Vercel 环境下启用自动删除会话失效

### DIFF
--- a/internal/httpapi/openai/chat/handler.go
+++ b/internal/httpapi/openai/chat/handler.go
@@ -33,6 +33,7 @@ type Handler struct {
 
 type streamLease struct {
 	Auth      *auth.RequestAuth
+	SessionID string
 	ExpiresAt time.Time
 }
 

--- a/internal/httpapi/openai/chat/vercel_prepare_test.go
+++ b/internal/httpapi/openai/chat/vercel_prepare_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -64,14 +65,14 @@ func TestVercelInternalSecret(t *testing.T) {
 
 func TestStreamLeaseLifecycle(t *testing.T) {
 	h := &Handler{}
-	leaseID := h.holdStreamLease(&auth.RequestAuth{UseConfigToken: false})
+	leaseID := h.holdStreamLease(&auth.RequestAuth{UseConfigToken: false}, "test-session-id")
 	if leaseID == "" {
 		t.Fatalf("expected non-empty lease id")
 	}
-	if ok := h.releaseStreamLease(leaseID); !ok {
+	if ok, _, _ := h.releaseStreamLease(leaseID); !ok {
 		t.Fatalf("expected lease release success")
 	}
-	if ok := h.releaseStreamLease(leaseID); ok {
+	if ok, _, _ := h.releaseStreamLease(leaseID); ok {
 		t.Fatalf("expected duplicate release to fail")
 	}
 }
@@ -138,6 +139,94 @@ func TestHandleVercelStreamPrepareAppliesCurrentInputFile(t *testing.T) {
 	refIDs, _ := payload["ref_file_ids"].([]any)
 	if len(refIDs) == 0 || refIDs[0] != "file-inline-1" {
 		t.Fatalf("expected uploaded history file first in ref_file_ids, got %#v", payload["ref_file_ids"])
+	}
+}
+
+type vercelReleaseAutoDeleteDSStub struct {
+	resp               *http.Response
+	deleteCallCount    int
+	deletedSessionID   string
+	deletedToken       string
+	deleteErr          error
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) CreateSession(_ context.Context, _ *auth.RequestAuth, _ int) (string, error) {
+	return "session-id", nil
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) GetPow(_ context.Context, _ *auth.RequestAuth, _ int) (string, error) {
+	return "pow", nil
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) UploadFile(_ context.Context, _ *auth.RequestAuth, _ dsclient.UploadFileRequest, _ int) (*dsclient.UploadFileResult, error) {
+	return &dsclient.UploadFileResult{ID: "file-id", Filename: "file.txt", Bytes: 1, Status: "uploaded"}, nil
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) CallCompletion(_ context.Context, _ *auth.RequestAuth, _ map[string]any, _ string, _ int) (*http.Response, error) {
+	return m.resp, nil
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) DeleteSessionForToken(_ context.Context, token string, sessionID string) (*dsclient.DeleteSessionResult, error) {
+	m.deleteCallCount++
+	m.deletedSessionID = sessionID
+	m.deletedToken = token
+	if m.deleteErr != nil {
+		return nil, m.deleteErr
+	}
+	return &dsclient.DeleteSessionResult{SessionID: sessionID, Success: true}, nil
+}
+
+func (m *vercelReleaseAutoDeleteDSStub) DeleteAllSessionsForToken(_ context.Context, _ string) error {
+	return nil
+}
+
+type vercelReleaseAuthStub struct{}
+
+func (a *vercelReleaseAuthStub) Determine(_ *http.Request) (*auth.RequestAuth, error) {
+	return &auth.RequestAuth{DeepSeekToken: "test-token", AccountID: "test-account"}, nil
+}
+
+func (a *vercelReleaseAuthStub) DetermineCaller(_ *http.Request) (*auth.RequestAuth, error) {
+	return &auth.RequestAuth{DeepSeekToken: "test-token", AccountID: "test-account"}, nil
+}
+
+func (a *vercelReleaseAuthStub) Release(_ *auth.RequestAuth) {}
+
+func TestHandleVercelStreamReleaseTriggersAutoDelete(t *testing.T) {
+	t.Setenv("VERCEL", "1")
+	t.Setenv("DS2API_VERCEL_INTERNAL_SECRET", "stream-secret")
+
+	ds := &vercelReleaseAutoDeleteDSStub{}
+	h := &Handler{
+		Store: mockOpenAIConfig{
+			autoDeleteMode: "single",
+		},
+		Auth: &vercelReleaseAuthStub{},
+		DS:   ds,
+	}
+
+	leaseID := h.holdStreamLease(&auth.RequestAuth{DeepSeekToken: "test-token", AccountID: "test-account"}, "session-to-delete")
+	if leaseID == "" {
+		t.Fatalf("expected non-empty lease id")
+	}
+
+	reqBody := map[string]any{"lease_id": leaseID}
+	reqJSON, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions?__stream_release=1", strings.NewReader(string(reqJSON)))
+	req.Header.Set("X-Ds2-Internal-Token", "stream-secret")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.handleVercelStreamRelease(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if ds.deleteCallCount != 1 {
+		t.Fatalf("expected auto delete call count=1, got %d", ds.deleteCallCount)
+	}
+	if ds.deletedSessionID != "session-to-delete" {
+		t.Fatalf("expected deleted session id=session-to-delete, got %q", ds.deletedSessionID)
 	}
 }
 

--- a/internal/httpapi/openai/chat/vercel_prepare_test.go
+++ b/internal/httpapi/openai/chat/vercel_prepare_test.go
@@ -143,11 +143,11 @@ func TestHandleVercelStreamPrepareAppliesCurrentInputFile(t *testing.T) {
 }
 
 type vercelReleaseAutoDeleteDSStub struct {
-	resp               *http.Response
-	deleteCallCount    int
-	deletedSessionID   string
-	deletedToken       string
-	deleteErr          error
+	resp             *http.Response
+	deleteCallCount  int
+	deletedSessionID string
+	deletedToken     string
+	deleteErr        error
 }
 
 func (m *vercelReleaseAutoDeleteDSStub) CreateSession(_ context.Context, _ *auth.RequestAuth, _ int) (string, error) {

--- a/internal/httpapi/openai/chat/vercel_stream.go
+++ b/internal/httpapi/openai/chat/vercel_stream.go
@@ -96,7 +96,7 @@ func (h *Handler) handleVercelStreamPrepare(w http.ResponseWriter, r *http.Reque
 	}
 
 	payload := stdReq.CompletionPayload(sessionID)
-	leaseID := h.holdStreamLease(a)
+	leaseID := h.holdStreamLease(a, sessionID)
 	if leaseID == "" {
 		writeOpenAIError(w, http.StatusInternalServerError, "failed to create stream lease")
 		return
@@ -140,9 +140,13 @@ func (h *Handler) handleVercelStreamRelease(w http.ResponseWriter, r *http.Reque
 		writeOpenAIError(w, http.StatusBadRequest, "lease_id is required")
 		return
 	}
-	if !h.releaseStreamLease(leaseID) {
+	ok, leaseAuth, sessionID := h.releaseStreamLease(leaseID)
+	if !ok {
 		writeOpenAIError(w, http.StatusNotFound, "stream lease not found")
 		return
+	}
+	if sessionID != "" && leaseAuth != nil {
+		h.autoDeleteRemoteSession(r.Context(), leaseAuth, sessionID)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"success": true})
 }
@@ -216,7 +220,7 @@ func vercelInternalSecret() string {
 	return "admin"
 }
 
-func (h *Handler) holdStreamLease(a *auth.RequestAuth) string {
+func (h *Handler) holdStreamLease(a *auth.RequestAuth, sessionID string) string {
 	if a == nil {
 		return ""
 	}
@@ -234,6 +238,7 @@ func (h *Handler) holdStreamLease(a *auth.RequestAuth) string {
 	leaseID := newLeaseID()
 	h.streamLeases[leaseID] = streamLease{
 		Auth:      a,
+		SessionID: sessionID,
 		ExpiresAt: now.Add(ttl),
 	}
 	h.leaseMu.Unlock()
@@ -255,10 +260,10 @@ func (h *Handler) lookupStreamLeaseAuth(leaseID string) *auth.RequestAuth {
 	return lease.Auth
 }
 
-func (h *Handler) releaseStreamLease(leaseID string) bool {
+func (h *Handler) releaseStreamLease(leaseID string) (bool, *auth.RequestAuth, string) {
 	leaseID = strings.TrimSpace(leaseID)
 	if leaseID == "" {
-		return false
+		return false, nil, ""
 	}
 
 	h.leaseMu.Lock()
@@ -271,12 +276,12 @@ func (h *Handler) releaseStreamLease(leaseID string) bool {
 	h.releaseExpiredAuths(expired)
 
 	if !ok {
-		return false
+		return false, nil, ""
 	}
 	if h.Auth != nil {
 		h.Auth.Release(lease.Auth)
 	}
-	return true
+	return true, lease.Auth, lease.SessionID
 }
 
 func (h *Handler) popExpiredLeasesLocked(now time.Time) []*auth.RequestAuth {


### PR DESCRIPTION
## 问题描述

在 Vercel 部署环境中，"删除当前对话"功能无法正常工作。用户开启自动删除后，对话仍然不会被删除。

## 问题分析

在 Vercel 部署环境中，流式请求使用了一种特殊的 "prepare-release" 两阶段流程：

1. **Prepare 阶段**：创建 session 并返回 `session_id`，但由于 Vercel 的冷启动优化，实际请求处理转移到 Node.js 端
2. **Release 阶段**：流结束后 Node.js 调用 Go 端释放 lease

原来的代码问题在于：
- 在 Prepare 阶段创建的 `sessionID` 没有保存到 lease 中
- Release 时虽然会释放 lease，但没有执行删除会话的逻辑

## 修复内容

### 1. handler.go

给 `streamLease` 结构体添加 `SessionID` 字段，用于保存会话 ID：

```go
type streamLease struct {
	Auth      *auth.RequestAuth
	SessionID string  // 新增
	ExpiresAt time.Time
}
```

### 2. vercel_stream.go

- `holdStreamLease` 函数添加 `sessionID` 参数
- `releaseStreamLease` 函数返回 `(bool, *auth.RequestAuth, string)` 三个值，包含认证信息和会话 ID
- `handleVercelStreamRelease` 在释放时调用 `autoDeleteRemoteSession` 触发自动删除

### 3. vercel_prepare_test.go

- 更新现有测试 `TestStreamLeaseLifecycle` 适配新签名
- 添加新测试 `TestHandleVercelStreamReleaseTriggersAutoDelete` 验证 Vercel 流释放时的自动删除功能

## 预期效果

当用户开启"仅删除当前对话"（auto_delete_mode=single）时：

- ✅ 在 Vercel 流式请求结束后，会正确调用 DeepSeek API 删除当前会话
- ✅ 会话被删除后，不会出现在用户的对话历史中
- ✅ 与非 Vercel 部署的行为保持一致

## 测试结果

所有相关单元测试均已通过：

| 测试用例 | 描述 | 状态 |
|---------|------|------|
| `TestHandleVercelStreamReleaseTriggersAutoDelete` | 验证 Vercel 流释放时触发自动删除 | ✅ 通过 |
| `TestStreamLeaseLifecycle` | 验证 lease 生命周期 | ✅ 通过 |
| `TestChatCompletionsAutoDeleteModes` | 验证自动删除模式 | ✅ 通过 |

## 影响范围

此修改**仅影响 Vercel 流式部署**