### PR TITLE
[codex] fix WebUI static root path guard

### DIFF
--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) serveFromDisk(w http.ResponseWriter, r *http.Request, staticDi
 	path = strings.TrimPrefix(path, "/")
 	if path != "" && strings.Contains(path, ".") {
 		full := filepath.Join(root, filepath.Clean(path))
-		if full != root && !strings.HasPrefix(full, root+string(os.PathSeparator)) {
+		if !isPathInsideRoot(full, root) {
 			http.NotFound(w, r)
 			return
 		}
@@ -125,6 +125,20 @@ func (h *Handler) serveFromDisk(w http.ResponseWriter, r *http.Request, staticDi
 	w.Header().Set("Cache-Control", "no-store, must-revalidate")
 	setStaticContentType(w, index)
 	http.ServeFile(w, r, index)
+}
+
+func isPathInsideRoot(path, root string) bool {
+	cleanPath := filepath.Clean(path)
+	cleanRoot := filepath.Clean(root)
+	if cleanPath == cleanRoot {
+		return true
+	}
+	volume := filepath.VolumeName(cleanRoot)
+	rootWithoutVolume := cleanRoot[len(volume):]
+	if rootWithoutVolume == string(os.PathSeparator) {
+		return strings.HasPrefix(cleanPath, cleanRoot)
+	}
+	return strings.HasPrefix(cleanPath, cleanRoot+string(os.PathSeparator))
 }
 
 func resolveStaticAdminDir(preferred string) string {

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -105,6 +105,25 @@ func TestServeFromDiskRejectsSiblingDirectoryWithSharedPrefix(t *testing.T) {
 	}
 }
 
+func TestIsPathInsideRootAllowsFilesystemRootChildren(t *testing.T) {
+	root := filepath.VolumeName(os.TempDir()) + string(os.PathSeparator)
+	child := filepath.Join(root, "assets", "index.css")
+
+	if !isPathInsideRoot(child, root) {
+		t.Fatalf("expected filesystem-root child %q inside %q", child, root)
+	}
+}
+
+func TestIsPathInsideRootRejectsSharedPrefixSibling(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "admin")
+	sibling := filepath.Join(parent, "admin-leak", "secret.txt")
+
+	if isPathInsideRoot(sibling, root) {
+		t.Fatalf("expected shared-prefix sibling %q outside %q", sibling, root)
+	}
+}
+
 // TestSetStaticContentTypeUnknownExtensionFallsThrough verifies that unknown
 // extensions leave the Content-Type header unset, so http.ServeFile can apply
 // its own detection (sniffing or mime.TypeByExtension) for cases the pinned


### PR DESCRIPTION
## Summary

Fix the WebUI static file containment check when `staticDir` is configured as a filesystem root, such as `/` on Unix or a drive root on Windows.

## Root Cause

The previous guard built the child prefix with `root + string(os.PathSeparator)`. For filesystem roots this becomes a doubled separator, so valid child paths under the root fail the prefix check and static assets return 404.

## Changes

- Add `isPathInsideRoot` to handle filesystem roots while preserving the path-separator boundary check for normal directories.
- Keep rejecting shared-prefix sibling paths such as `admin-leak`.
- Add regression tests for filesystem-root children and shared-prefix sibling rejection.

## Validation

- `./scripts/lint.sh`
- `./tests/scripts/check-refactor-line-gate.sh`
- `./tests/scripts/run-unit-all.sh`
- `npm run build --prefix webui`
